### PR TITLE
Closes i-RIC/prepost-gui#109

### DIFF
--- a/libs/post/post2d/datamodel/post2dwindownodevectorstreamlinegroupdataitem.cpp
+++ b/libs/post/post2d/datamodel/post2dwindownodevectorstreamlinegroupdataitem.cpp
@@ -87,7 +87,6 @@ void Post2dWindowNodeVectorStreamlineGroupDataItem::updateActorSettings()
 {
 	for (auto actor : m_streamlineActors) {
 		renderer()->RemoveActor(actor);
-		actor->Delete();
 	}
 	m_actorCollection->RemoveAllItems();
 	m_streamlineActors.clear();


### PR DESCRIPTION
deleted actor->Delete(); since original actor was instantiated using vtkSmartPointer\<vtkActor\>
[Post2dWindowNodeVectorStreamlineGroupStructuredDataItem::setupActors](https://github.com/i-RIC/prepost-gui/blob/3ac00eae83fe94e50ac20935ddc279cfe06cc6df/libs/post/post2d/datamodel/post2dwindownodevectorstreamlinegroupstructureddataitem.cpp#L107)