### PR TITLE
Closes i-RIC/prepost-gui#128

### DIFF
--- a/libs/gui/main/iricmainwindow.cpp
+++ b/libs/gui/main/iricmainwindow.cpp
@@ -275,7 +275,7 @@ void iRICMainWindow::newProject(SolverDefinitionAbstract* solver)
 	// show pre-processor window first.
 	PreProcessorWindow* pre = dynamic_cast<PreProcessorWindow*>(m_preProcessorWindow);
 	pre->setupDefaultGeometry();
-	pre->parentWidget()->show();
+	focusPreProcessorWindow();
 	m_actionManager->informSubWindowChange(pre);
 	m_solverConsoleWindow->setupDefaultGeometry();
 	m_solverConsoleWindow->parentWidget()->hide();


### PR DESCRIPTION
iRICMainWindow::newProject() now uses iRICMainWindow::focusPreProcessorWindow() for showing and focusing PreProcessor Window, and because of this, X, Y is shown on status bar immediately after starting new project.