### PR TITLE
Closes i-RIC/prepost-gui#164

### DIFF
--- a/libs/gui/main/iricmainwindow.cpp
+++ b/libs/gui/main/iricmainwindow.cpp
@@ -461,7 +461,7 @@ void iRICMainWindow::importCalculationResult()
 
 void iRICMainWindow::importCalculationResult(const QString& fname)
 {
-	// check whether the project file exists.
+	// check whether the CGNS file exists.
 	if (! QFile::exists(fname)) {
 		// the CGNS file does not exists!
 		QMessageBox::warning(this, tr("Warning"), tr("CGNS file %1 does not exists.").arg(QDir::toNativeSeparators(fname)));

--- a/libs/guicore/project/projectmainfile.cpp
+++ b/libs/guicore/project/projectmainfile.cpp
@@ -509,52 +509,6 @@ QStringList ProjectMainFile::containedFiles()
 	return ret;
 }
 
-void ProjectMainFile::importCgnsFile()
-{
-	QString fname = QFileDialog::getOpenFileName(
-										m_projectData->mainWindow(), tr("Import CGNS file"), LastIODirectory::get(), tr("CGNS file (*.cgn)")
-									);
-	if (fname == "") {return;}
-	importCgnsFile(fname);
-}
-
-void ProjectMainFile::importCgnsFile(const QString& fname)
-{
-	QString fnamebody = QFileInfo(fname).baseName();
-	if (m_cgnsFileList->exists(fnamebody)) {
-		QMessageBox::critical(m_projectData->mainWindow(), tr("Error"), QString(tr("Solution %1 already exists.").arg(fnamebody)));
-		return;
-	}
-	QRegExp rx(ProjectCgnsFile::acceptablePattern());
-	if (rx.indexIn(fnamebody) == - 1) {
-		QMessageBox::critical(m_projectData->mainWindow(), tr("Error"), QString(tr("CGNS file whose name contains characters other than alphabets and numbers can not be imported.")));
-		return;
-	}
-
-	m_cgnsFileList->add(fnamebody);
-	QString to = m_projectData->workCgnsFileName(fnamebody);
-	QFile::copy(fname, to);
-
-	std::string solverName;
-	VersionNumber versionNumber;
-
-	bool ret = ProjectCgnsFile::readSolverInfo(to, &solverName, &versionNumber);
-	if (ret == true){
-		if (impl->m_solverName != solverName || (! impl->m_solverVersion.compatibleWith(versionNumber))){
-			projectData()->setPostOnlyMode();
-		}
-	} else {
-		// error occured reading solver information.
-		projectData()->setPostOnlyMode();
-	}
-	QFileInfo finfo(fname);
-	LastIODirectory::set(finfo.absolutePath());
-	switchCgnsFile(fnamebody);
-
-	// CGNS file import is not undo-able.
-	iRICUndoStack::instance().clear();
-}
-
 bool ProjectMainFile::importCgnsFile(const QString& fname, const QString& newname)
 {
 	QString fnamebody = QFileInfo(newname).baseName();

--- a/libs/guicore/project/projectmainfile.h
+++ b/libs/guicore/project/projectmainfile.h
@@ -98,7 +98,6 @@ public:
 	const QList<vtkRenderer*>& renderers() const;
 
 	void updateActorVisibility(int idx, bool vis);
-	void importCgnsFile(const QString& filename);
 	bool importCgnsFile(const QString& filename, const QString& newname);
 	/// Import Measured data from CSV files.
 	void addMeasuredData();
@@ -119,7 +118,6 @@ public:
 	int showCoordinateSystemDialog(bool forceSelect = false);
 
 public slots:
-	void importCgnsFile();
 	void exportCurrentCgnsFile();
 	bool switchCgnsFile(const QString& name);
 


### PR DESCRIPTION
When the calculation result is in multiple CGNS files, i. e. not all in Case1.cgn, but in Case1_Solution1.cgn, Case1_Solution2.cgn, ..., iRIC GUI only copies Case1.cgn, and loading calculation result fails.