### PR TITLE
Closes issues related to cg_open() collision between solvers and iRIC GUI.

### DIFF
--- a/libs/guicore/guicore.pro
+++ b/libs/guicore/guicore.pro
@@ -210,6 +210,7 @@ HEADERS += guicore_global.h \
            datamodel/vtk3dgraphicsview.h \
            datamodel/vtkgraphicsview.h \
            executer/iricmainwindowexecuterwatcher.h \
+           misc/cgnsfileopener.h \
            misc/cgnslinkfollower.h \
            misc/iricmetadata.h \
            misc/mouseboundingbox.h \
@@ -295,6 +296,7 @@ HEADERS += guicore_global.h \
            datamodel/private/graphicswindowrootdataitem_movedowncommand.h \
            datamodel/private/graphicswindowrootdataitem_moveupcommand.h \
            datamodel/private/vtkgraphicsview_impl.h \
+           misc/private/cgnsfileopener_impl.h \
            misc/private/cgnslinkfollower_impl.h \
            misc/targeted/targeteditemi.h \
            misc/targeted/targeteditemsettargetcommand.h \
@@ -532,6 +534,7 @@ SOURCES += base/iricmainwindowinterface.cpp \
            datamodel/vtk3dgraphicsview.cpp \
            datamodel/vtkgraphicsview.cpp \
            executer/iricmainwindowexecuterwatcher.cpp \
+           misc/cgnsfileopener.cpp \
            misc/cgnslinkfollower.cpp \
            misc/iricmetadata.cpp \
            misc/mouseboundingbox.cpp \

--- a/libs/guicore/misc/cgnsfileopener.cpp
+++ b/libs/guicore/misc/cgnsfileopener.cpp
@@ -1,0 +1,50 @@
+#include "cgnsfileopener.h"
+#include "private/cgnsfileopener_impl.h"
+
+#include <cgnslib.h>
+
+#include <stdexcept>
+
+namespace {
+
+std::string lock_filename(const std::string& filename)
+{
+	std::string l_filename = filename;
+	l_filename.append(".lock");
+
+	return l_filename;
+}
+
+} // namespace
+
+CgnsFileOpener::Impl::Impl(const std::string &filename) :
+	m_fileId {0},
+	m_fileLocker {lock_filename(filename)}
+{}
+
+CgnsFileOpener::CgnsFileOpener(const std::string& filename, int openMode) :
+	impl {new Impl {filename}}
+{
+	bool ok = impl->m_fileLocker.lock();
+	if (! ok) {
+		throw std::runtime_error("CGNS file open error");
+	}
+	int ier = cg_open(filename.c_str(), openMode, &(impl->m_fileId));
+	if (ier != 0) {
+		impl->m_fileLocker.unlock();
+		throw std::runtime_error("CGNS file open error");
+	}
+}
+
+CgnsFileOpener::~CgnsFileOpener()
+{
+	cg_close(impl->m_fileId);
+	impl->m_fileLocker.unlock();
+
+	delete impl;
+}
+
+int CgnsFileOpener::fileId() const
+{
+	return impl->m_fileId;
+}

--- a/libs/guicore/misc/cgnsfileopener.h
+++ b/libs/guicore/misc/cgnsfileopener.h
@@ -1,0 +1,21 @@
+#ifndef CGNSFILEOPENER_H
+#define CGNSFILEOPENER_H
+
+#include "../guicore_global.h"
+
+#include <string>
+
+class GUICOREDLL_EXPORT CgnsFileOpener
+{
+public:
+	CgnsFileOpener(const std::string& filename, int openMode);
+	~CgnsFileOpener();
+
+	int fileId() const;
+
+private:
+	class Impl;
+	Impl* impl;
+};
+
+#endif // CGNSFILEOPENER_H

--- a/libs/guicore/misc/private/cgnsfileopener_impl.h
+++ b/libs/guicore/misc/private/cgnsfileopener_impl.h
@@ -1,0 +1,17 @@
+#ifndef CGNSFILEOPENER_IMPL_H
+#define CGNSFILEOPENER_IMPL_H
+
+#include "../cgnsfileopener.h"
+
+#include <filelocker.h>
+
+class CgnsFileOpener::Impl
+{
+public:
+	Impl(const std::string& filename);
+
+	int m_fileId;
+	FileLocker m_fileLocker;
+};
+
+#endif // CGNSFILEOPENER_IMPL_H

--- a/libs/guicore/postcontainer/postsolutioninfo.h
+++ b/libs/guicore/postcontainer/postsolutioninfo.h
@@ -11,6 +11,7 @@
 #include <QMap>
 #include <QStringList>
 
+class CgnsFileOpener;
 class PostIterationSteps;
 class PostTimeSteps;
 class PostDataContainer;
@@ -114,7 +115,7 @@ private:
 	bool m_baseIterativeDataExists;
 	QList<PostDataContainer*> m_otherContainers;
 	int m_timerId;
-	int m_fileId;
+	CgnsFileOpener* m_opener;
 
 	std::vector<std::string> m_zoneNames1D;
 	std::vector<std::string> m_zoneNames2D;

--- a/libs/post/graph2dhybrid/datamodel/graph2dhybridwindowbaseiterativeresultdataitem.cpp
+++ b/libs/post/graph2dhybrid/datamodel/graph2dhybridwindowbaseiterativeresultdataitem.cpp
@@ -19,8 +19,8 @@
 #include <cmath>
 #include <qwt_plot_curve.h>
 
-Graph2dHybridWindowBaseIterativeResultDataItem::Graph2dHybridWindowBaseIterativeResultDataItem(const Graph2dHybridWindowResultSetting::Setting& setting, int index, Graph2dWindowDataItem* parent)
-	: Graph2dHybridWindowResultDataItem(setting.name(), index, setting, parent)
+Graph2dHybridWindowBaseIterativeResultDataItem::Graph2dHybridWindowBaseIterativeResultDataItem(const Graph2dHybridWindowResultSetting::Setting& setting, int index, Graph2dWindowDataItem* parent) :
+	Graph2dHybridWindowResultDataItem(setting.name(), index, setting, parent)
 {
 	const Graph2dHybridWindowResultSetting& s = dataModel()->setting();
 	Graph2dHybridWindowResultSetting::DataTypeInfo* info = s.targetDataTypeInfo();
@@ -28,18 +28,13 @@ Graph2dHybridWindowBaseIterativeResultDataItem::Graph2dHybridWindowBaseIterative
 }
 
 Graph2dHybridWindowBaseIterativeResultDataItem::~Graph2dHybridWindowBaseIterativeResultDataItem()
-{
-}
+{}
 
 void Graph2dHybridWindowBaseIterativeResultDataItem::doLoadFromProjectMainFile(const QDomNode& /*node*/)
-{
-
-}
+{}
 
 void Graph2dHybridWindowBaseIterativeResultDataItem::doSaveToProjectMainFile(QXmlStreamWriter& /*writer*/)
-{
-
-}
+{}
 
 void Graph2dHybridWindowBaseIterativeResultDataItem::updateValues(int fn)
 {

--- a/libs/post/graph2dhybrid/datamodel/graph2dhybridwindowbaseiterativeresultdataitem.h
+++ b/libs/post/graph2dhybrid/datamodel/graph2dhybridwindowbaseiterativeresultdataitem.h
@@ -13,7 +13,8 @@ class Graph2dHybridWindowBaseIterativeResultDataItem : public Graph2dHybridWindo
 
 public:
 	Graph2dHybridWindowBaseIterativeResultDataItem(const Graph2dHybridWindowResultSetting::Setting& setting, int index, Graph2dWindowDataItem* parent);
-	virtual ~Graph2dHybridWindowBaseIterativeResultDataItem();
+	~Graph2dHybridWindowBaseIterativeResultDataItem();
+
 	void doLoadFromProjectMainFile(const QDomNode& node) override;
 	void doSaveToProjectMainFile(QXmlStreamWriter& writer) override;
 	Graph2dHybridWindowResultCopyDataItem* copy(Graph2dHybridWindowResultCopyGroupDataItem* parent) override;

--- a/libs/post/graph2dhybrid/graph2dhybridwindowlinesettingdialog.cpp
+++ b/libs/post/graph2dhybrid/graph2dhybridwindowlinesettingdialog.cpp
@@ -14,14 +14,19 @@ Graph2dHybridWindowLineSettingDialog::~Graph2dHybridWindowLineSettingDialog()
 	delete ui;
 }
 
+int Graph2dHybridWindowLineSettingDialog::lineWidth() const
+{
+	return ui->widthSpinBox->value();
+}
+
 void Graph2dHybridWindowLineSettingDialog::setLineWidth(int width)
 {
 	ui->widthSpinBox->setValue(width);
 }
 
-int Graph2dHybridWindowLineSettingDialog::lineWidth()
+QColor Graph2dHybridWindowLineSettingDialog::customColor() const
 {
-	return ui->widthSpinBox->value();
+	return ui->colorWidget->color();
 }
 
 void Graph2dHybridWindowLineSettingDialog::setCustomColor(QColor col)
@@ -29,9 +34,13 @@ void Graph2dHybridWindowLineSettingDialog::setCustomColor(QColor col)
 	ui->colorWidget->setColor(col);
 }
 
-QColor Graph2dHybridWindowLineSettingDialog::customColor()
+Graph2dHybridWindowResultSetting::AxisSide Graph2dHybridWindowLineSettingDialog::axisSide() const
 {
-	return ui->colorWidget->color();
+	if (ui->yAxisLeftRadioButton->isChecked()) {
+		return Graph2dHybridWindowResultSetting::asLeft;
+	} else {
+		return Graph2dHybridWindowResultSetting::asRight;
+	}
 }
 
 void Graph2dHybridWindowLineSettingDialog::setAxisSide(Graph2dHybridWindowResultSetting::AxisSide side)
@@ -40,15 +49,5 @@ void Graph2dHybridWindowLineSettingDialog::setAxisSide(Graph2dHybridWindowResult
 		ui->yAxisLeftRadioButton->setChecked(true);
 	} else {
 		ui->yAxisRightRadioButton->setChecked(true);
-	}
-
-}
-
-Graph2dHybridWindowResultSetting::AxisSide Graph2dHybridWindowLineSettingDialog::axisSide()
-{
-	if (ui->yAxisLeftRadioButton->isChecked()) {
-		return Graph2dHybridWindowResultSetting::asLeft;
-	} else {
-		return Graph2dHybridWindowResultSetting::asRight;
 	}
 }

--- a/libs/post/graph2dhybrid/graph2dhybridwindowlinesettingdialog.h
+++ b/libs/post/graph2dhybrid/graph2dhybridwindowlinesettingdialog.h
@@ -17,12 +17,15 @@ class Graph2dHybridWindowLineSettingDialog : public QDialog
 public:
 	explicit Graph2dHybridWindowLineSettingDialog(QWidget* parent = nullptr);
 	~Graph2dHybridWindowLineSettingDialog();
+
+	int lineWidth() const;
 	void setLineWidth(int width);
-	int lineWidth();
+
+	QColor customColor() const;
 	void setCustomColor(QColor col);
-	QColor customColor();
+
+	Graph2dHybridWindowResultSetting::AxisSide axisSide() const;
 	void setAxisSide(Graph2dHybridWindowResultSetting::AxisSide side);
-	Graph2dHybridWindowResultSetting::AxisSide axisSide();
 
 private:
 	Ui::Graph2dHybridWindowLineSettingDialog* ui;

--- a/libs/post/graph2dscattered/graph2dscatteredwindowdatamodel.cpp
+++ b/libs/post/graph2dscattered/graph2dscatteredwindowdatamodel.cpp
@@ -1,24 +1,24 @@
 #define _USE_MATH_DEFINES
 #include <cmath>
 
-#include "datamodel/graph2dscatteredwindowrootdataitem.h"
-#include "datamodel/graph2dscatteredwindowresultgroupdataitem.h"
-#include <guicore/base/iricmainwindowinterface.h>
-#include "graph2dscatteredwindowdatamodel.h"
-#include <guicore/project/projectdata.h>
-#include "graph2dscatteredwindow.h"
-#include "graph2dscatteredwindowview.h"
-#include "graph2dscatteredwindowdatasourcedialog.h"
-#include "graph2dscatteredaxissettingdialog.h"
-#include "graph2dscatteredwindowdrawsettingdialog.h"
-#include <misc/stringtool.h>
-#include <misc/xmlsupport.h>
-#include <misc/errormessage.h>
-#include <guicore/postcontainer/posttimesteps.h>
 #include "datamodel/graph2dscatteredwindowresultdataitem.h"
+#include "datamodel/graph2dscatteredwindowresultgroupdataitem.h"
+#include "datamodel/graph2dscatteredwindowrootdataitem.h"
+#include "graph2dscatteredaxissettingdialog.h"
+#include "graph2dscatteredwindow.h"
+#include "graph2dscatteredwindowdatamodel.h"
+#include "graph2dscatteredwindowdatasourcedialog.h"
+#include "graph2dscatteredwindowdrawsettingdialog.h"
+#include "graph2dscatteredwindowview.h"
 
+#include <guicore/base/iricmainwindowinterface.h>
+#include <guicore/postcontainer/posttimesteps.h>
+#include <guicore/project/projectdata.h>
 #include <guicore/project/projectmainfile.h>
 #include <guibase/objectbrowserview.h>
+#include <misc/errormessage.h>
+#include <misc/stringtool.h>
+#include <misc/xmlsupport.h>
 
 #include <QDomNode>
 #include <QFile>

--- a/libs/pre/datamodel/preprocessorinputconditiondataitem.cpp
+++ b/libs/pre/datamodel/preprocessorinputconditiondataitem.cpp
@@ -66,8 +66,9 @@ void PreProcessorInputConditionDataItem::showDialog(bool readonly)
 {
 	projectData()->mainfile()->postSolutionInfo()->close();
 
-	auto opener = CgnsFileOpener(projectData()->currentCgnsFileName(), CG_MODE_READ);
-	loadFromCgnsFile(opener.fileId());
+	auto fname = projectData()->currentCgnsFileName();
+	auto opener = new CgnsFileOpener(iRIC::toStr(fname), CG_MODE_READ);
+	loadFromCgnsFile(opener->fileId());
 	delete opener;
 
 	// set default folder for filename input conditions.

--- a/libs/pre/datamodel/preprocessorinputconditiondataitem.cpp
+++ b/libs/pre/datamodel/preprocessorinputconditiondataitem.cpp
@@ -1,6 +1,7 @@
 #include "preprocessorinputconditiondataitem.h"
 
 #include <guicore/base/iricmainwindowinterface.h>
+#include <guicore/misc/cgnsfileopener.h>
 #include <guicore/postcontainer/postsolutioninfo.h>
 #include <guicore/project/inputcond/inputconditiondialog.h>
 #include <guicore/project/inputcond/inputconditionwidgetfilename.h>
@@ -64,12 +65,11 @@ void PreProcessorInputConditionDataItem::saveToCgnsFile(const int fn)
 void PreProcessorInputConditionDataItem::showDialog(bool readonly)
 {
 	projectData()->mainfile()->postSolutionInfo()->close();
-	QString fname = projectData()->currentCgnsFileName();
-	int fn;
-	cg_open(iRIC::toStr(fname).c_str(), CG_MODE_READ, &fn);
-	// load data.
-	loadFromCgnsFile(fn);
-	cg_close(fn);
+
+	auto opener = CgnsFileOpener(projectData()->currentCgnsFileName(), CG_MODE_READ);
+	loadFromCgnsFile(opener.fileId());
+	delete opener;
+
 	// set default folder for filename input conditions.
 	InputConditionWidgetFilename::defaultFolder = LastIODirectory::get();
 	m_dialog->setFileName(fname);


### PR DESCRIPTION
iRIC GUI had issues related to cg_open() collision between solvers and iRIC GUI.

Now in iRIC, CgnsFileOpener class that avoids cg_open collision is used, that internally uses FileLocker class that we implemented in i-RIC/iriclib#19.
