### PR TITLE
Closes i-RIC/prepost-gui#201

### DIFF
--- a/libs/guicore/guicore.pro
+++ b/libs/guicore/guicore.pro
@@ -162,6 +162,16 @@ LIBS += \
 	-lvtkRenderingLOD-6.1 \
 	-lvtkRenderingQt-6.1
 
+
+# hdf5
+win32 {
+	CONFIG(debug, debug|release) {
+		LIBS += -lhdf5_D
+	} else {
+		LIBS += -lhdf5
+	}
+}
+
 # cgnslib
 
 win32{

--- a/libs/guicore/misc/cgnsfileopener.cpp
+++ b/libs/guicore/misc/cgnsfileopener.cpp
@@ -1,6 +1,9 @@
 #include "cgnsfileopener.h"
 #include "private/cgnsfileopener_impl.h"
 
+#ifdef _MSC_VER
+#include <hdf5.h>
+#endif
 #include <cgnslib.h>
 
 #include <stdexcept>
@@ -39,6 +42,11 @@ CgnsFileOpener::CgnsFileOpener(const std::string& filename, int openMode) :
 CgnsFileOpener::~CgnsFileOpener()
 {
 	cg_close(impl->m_fileId);
+#ifdef _MSC_VER
+	// force linked files to close like Case1_Solution1.cgn, Case1_Solution2.cgn, ...
+	herr_t err = H5close();
+	Q_ASSERT(err == 0);
+#endif
 	impl->m_fileLocker.unlock();
 
 	delete impl;

--- a/libs/guicore/project/projectmainfile.cpp
+++ b/libs/guicore/project/projectmainfile.cpp
@@ -1,4 +1,5 @@
 #include "../base/iricmainwindowinterface.h"
+#include "../misc/cgnsfileopener.h"
 #include "../postcontainer/postsolutioninfo.h"
 #include "../pre/base/preprocessordatamodelinterface.h"
 #include "../pre/base/preprocessorwindowinterface.h"
@@ -579,22 +580,21 @@ QString ProjectMainFile::currentCgnsFileName() const
 
 bool ProjectMainFile::loadCgnsFile(const QString& name)
 {
-	// CGNS file name
-	QString fname = m_projectData->workCgnsFileName(name);
-	// save to current cgns file.
-	int fn;
-	int ret;
-	ret = cg_open(iRIC::toStr(fname).c_str(), CG_MODE_READ, &fn);
-	if (ret != 0) {
+	bool ret = false;
+	try {
+		// CGNS file name
+		QString fname = m_projectData->workCgnsFileName(name);
+		CgnsFileOpener opener(iRIC::toStr(fname), CG_MODE_READ);
+		// load data.
+		ret = true;
+		loadFromCgnsFile(opener.fileId());
+	}
+	catch (const std::runtime_error&) {
 		QString shortFilename = name;
 		shortFilename.append(".cgn");
 		QMessageBox::critical(m_projectData->mainWindow(), tr("Error"), tr("Error occured while opening CGNS file in project file : %1").arg(shortFilename));
-		return false;
 	}
-	// load data.
-	loadFromCgnsFile(fn);
-	cg_close(fn);
-	return true;
+	return ret;
 }
 
 bool ProjectMainFile::saveCgnsFile()

--- a/paths_std.pri
+++ b/paths_std.pri
@@ -75,6 +75,9 @@ INCLUDEPATH += "E:/iricdev_2013/lib/install/gdal-1.11.2/debug/include"
 # vtk
 INCLUDEPATH += "E:/iricdev_2013/lib/install/vtk-6.1.0/debug/include/vtk-6.1"
 
+# hdf5
+INCLUDEPATH += "E:/iricdev_2013/lib/install/hdf5-1.8.14/release/include"
+
 # cgnslib
 INCLUDEPATH += "E:/iricdev_2013/lib/install/cgnslib-3.2.1/debug/include"
 


### PR DESCRIPTION
Hi Keisuke,

This seems to be due to a bug in hdf5.  When opening a file with external links when cgns calls `cgi_read_zone` the external links are opened and closed many many times which seems to cause the hdf5 files to stay open.  To fix I added a call to `H5close` within the CgnsFileOpener destructor.

Note you'll need to update your paths.pri for the hdf5 include path and rerun qmake.

Thanks,
Scott