### PR TITLE
Fix bugs in RivMaker

### DIFF
--- a/apps/rivmaker/data/base/rootdataitem.cpp
+++ b/apps/rivmaker/data/base/rootdataitem.cpp
@@ -9,6 +9,7 @@
 #include <misc/xmlsupport.h>
 
 #include <QDomElement>
+#include <QPointF>
 #include <QStandardItem>
 #include <QXmlStreamWriter>
 
@@ -39,6 +40,11 @@ DataItemView* RootDataItem::buildPreProcessorDataItemView(Model *model)
 
 void RootDataItem::doLoadFromMainFile(const QDomElement& node)
 {
+	double offsetx, offsety;
+	offsetx = iRIC::getDoubleAttribute(node, "offsetX");
+	offsety = iRIC::getDoubleAttribute(node, "offsetY");
+	m_project->setOffset(QPointF(offsetx, offsety));
+
 	QDomElement epElem = iRIC::getChildNode(node, "ElevationPoints").toElement();
 	if (! epElem.isNull()) {
 		project()->elevationPoints().loadFromMainFile(epElem);
@@ -62,6 +68,10 @@ void RootDataItem::doLoadFromMainFile(const QDomElement& node)
 
 void RootDataItem::doSaveToMainFile(QXmlStreamWriter* writer) const
 {
+	auto offset = m_project->offset();
+	iRIC::setDoubleAttribute(*writer, "offsetX", offset.x());
+	iRIC::setDoubleAttribute(*writer, "offsetY", offset.y());
+
 	writer->writeStartElement("ElevationPoints");
 	project()->elevationPoints().saveToMainFile(writer);
 	writer->writeEndElement();

--- a/apps/rivmaker/data/project/project.cpp
+++ b/apps/rivmaker/data/project/project.cpp
@@ -173,6 +173,7 @@ bool Project::load(const QString& filename)
 	impl->m_isModified = false;
 
 	updatePointsAutoSize();
+	mapPointsToCrossSections();
 
 	return true;
 }

--- a/apps/rivmaker/dialogs/mappingsettingdialog.ui
+++ b/apps/rivmaker/dialogs/mappingsettingdialog.ui
@@ -292,7 +292,7 @@
               <double>0.010000000000000</double>
              </property>
              <property name="maximum">
-              <double>100.000000000000000</double>
+              <double>1000.000000000000000</double>
              </property>
              <property name="value">
               <double>5.000000000000000</double>
@@ -315,7 +315,7 @@
               <double>0.010000000000000</double>
              </property>
              <property name="maximum">
-              <double>100.000000000000000</double>
+              <double>1000.000000000000000</double>
              </property>
              <property name="value">
               <double>5.000000000000000</double>
@@ -338,7 +338,7 @@
               <double>0.010000000000000</double>
              </property>
              <property name="maximum">
-              <double>100.000000000000000</double>
+              <double>1000.000000000000000</double>
              </property>
              <property name="value">
               <double>5.000000000000000</double>
@@ -384,7 +384,7 @@
               <double>1.000000000000000</double>
              </property>
              <property name="maximum">
-              <double>10.000000000000000</double>
+              <double>100.000000000000000</double>
              </property>
              <property name="value">
               <double>3.000000000000000</double>
@@ -436,12 +436,6 @@
     </widget>
    </item>
   </layout>
-  <zorder>buttonBox</zorder>
-  <zorder>nearestRadioButton</zorder>
-  <zorder>tinRadioButton</zorder>
-  <zorder>templateRadioButton</zorder>
-  <zorder>verticalSpacer_2</zorder>
-  <zorder>verticalSpacer_3</zorder>
  </widget>
  <resources>
   <include location="../rivmaker.qrc"/>


### PR DESCRIPTION
Fixes the following bugs in RivMaker:
* Offset value is not properly saved to project file
* Cross-section window shows nothing after opening project file (*.rpro)
* Maximum value of items on MappingSettingDialog is now larger.
