### PR TITLE
Closes i-RIC/prepost-gui#42

### DIFF
--- a/libs/pre/datamodel/preprocessorbcdataitem.cpp
+++ b/libs/pre/datamodel/preprocessorbcdataitem.cpp
@@ -119,12 +119,12 @@ void PreProcessorBCDataItem::loadExternalData(const QString& filename)
 {
 	if (buildNumber() <= 3507) {return;}
 	int fn;
-	int ier = cg_open(iRIC::toStr(filename).c_str(), CG_MODE_MODIFY, &fn);
+	int ier = cg_open(iRIC::toStr(filename).c_str(), CG_MODE_READ, &fn);
 	if (ier != 0) {
 		// Opening CGNS file failed.
 		return;
 	}
-	cg_iRIC_Init(fn);
+	cg_iRIC_InitRead(fn);
 	// when loading, use 1 for number.
 	m_dialog->setNameAndNumber(TMPBCNAME, 1);
 	m_dialog->load(fn);


### PR DESCRIPTION
All codes related to cg_open functions are reviewed, and founded a place that uses cg_open with CG_MODE_MODIFY, where it only loads data, no modification. The code is changed to open with CG_MODE_READ.