### PR TITLE
Export CSV file button is disabled until CSV file name is set.

### DIFF
--- a/apps/rivmaker/data/project/project.cpp
+++ b/apps/rivmaker/data/project/project.cpp
@@ -283,6 +283,11 @@ void Project::setRivFileName(const QString& rivFileName)
     impl->m_rivFileName = rivFileName;
 }
 
+bool Project::isCsvFileNameSet() const
+{
+    return ! impl->m_csvFileName.isEmpty();
+}
+
 const QString& Project::csvFileName() const
 {
     return impl->m_csvFileName;
@@ -291,6 +296,8 @@ const QString& Project::csvFileName() const
 void Project::setCsvFileName(const QString& csvFileName)
 {
     impl->m_csvFileName = csvFileName;
+
+    emit csvFileNameSet(isCsvFileNameSet());
 }
 
 void Project::updatePointsAutoSize()

--- a/apps/rivmaker/data/project/project.h
+++ b/apps/rivmaker/data/project/project.h
@@ -53,6 +53,7 @@ public:
     const QString& rivFileName() const;
     void setRivFileName(const QString& rivFileName);
 
+    bool isCsvFileNameSet() const;
     const QString& csvFileName() const;
     void setCsvFileName(const QString& csvFileName);
 
@@ -94,6 +95,7 @@ public slots:
 
 signals:
 	void updated();
+    void csvFileNameSet(bool set);
 
 private:
 	class Impl;

--- a/apps/rivmaker/window/verticalcrosssection/verticalcrosssectionwindow.cpp
+++ b/apps/rivmaker/window/verticalcrosssection/verticalcrosssectionwindow.cpp
@@ -162,7 +162,9 @@ VerticalCrossSectionWindow::~VerticalCrossSectionWindow()
 void VerticalCrossSectionWindow::setProject(Project* project)
 {
 	m_project = project;
+    setCsvExportEnabled(project->isCsvFileNameSet());
 	connect(m_project, SIGNAL(updated()), this, SLOT(updateView()));
+    connect(m_project, SIGNAL(csvFileNameSet(bool)), this, SLOT(setCsvExportEnabled(bool)));
 	updateView();
 }
 
@@ -193,6 +195,11 @@ void VerticalCrossSectionWindow::exportWaterSurfaceElevation()
 void VerticalCrossSectionWindow::resetZoom()
 {
 	m_zoomer->zoom(0);
+}
+
+void VerticalCrossSectionWindow::setCsvExportEnabled(bool enabled)
+{
+    ui->exportButton->setEnabled(enabled);
 }
 
 void VerticalCrossSectionWindow::initPlot()

--- a/apps/rivmaker/window/verticalcrosssection/verticalcrosssectionwindow.h
+++ b/apps/rivmaker/window/verticalcrosssection/verticalcrosssectionwindow.h
@@ -35,6 +35,7 @@ private slots:
 	void handleTableEdit(QStandardItem* editedItem);
 	void exportWaterSurfaceElevation();
 	void resetZoom();
+    void setCsvExportEnabled(bool enabled);
 
 private:
 	void initPlot();


### PR DESCRIPTION
This is a RivMaker fix.