### PR TITLE
Closes i-RIC/prepost-gui#276

### DIFF
--- a/libs/geodata/riversurvey/geodatariversurveyimporter.h
+++ b/libs/geodata/riversurvey/geodatariversurveyimporter.h
@@ -1,8 +1,15 @@
 #ifndef GEODATARIVERSURVEYIMPORTER_H
 #define GEODATARIVERSURVEYIMPORTER_H
 
-#include <guicore/pre/geodata/geodataimporter.h>
 #include "geodatariversurveyimportersettingdialog.h"
+
+#include <guicore/pre/geodata/geodataimporter.h>
+
+#include <vector>
+
+namespace {
+class RivPathPoint;
+}
 
 class GeoDataRiverSurveyImporter : public GeoDataImporter
 {
@@ -16,6 +23,13 @@ public:
 	const QStringList acceptableExtensions() override;
 
 private:
+	bool doInit(const QString& filename, const QString& selectedFilter, int* count, SolverDefinitionGridAttribute* condition, PreProcessorGeoDataGroupDataItemInterface* item, QWidget* w) override;
+	void clearPoints();
+
+	std::vector<RivPathPoint*> m_points;
+	bool m_with4Points;
+	bool m_allNamesAreNumber;
+	bool m_reverseOrder;
 	GeoDataRiverSurveyImporterSettingDialog::CenterPointSetting m_cpSetting;
 };
 


### PR DESCRIPTION
Hi Scott,

I've reviewed the code, and decided that I fix the issue by implementing GeoDataRiverSurveyImporter::doInit().
Now the behavior when pressing cancel button is compatible with DEM data (*.tpo) dialog, and easier to understand for users, I think.

It is different from the way you've proposed, but I hope you feel this way is acceptable.
Thanks,

Keisuke