### PR TITLE
Closes #296, Closes #292

### DIFF
--- a/libs/guicore/tmsimage/private/tmsregionselectwidget_impl.h
+++ b/libs/guicore/tmsimage/private/tmsregionselectwidget_impl.h
@@ -7,6 +7,7 @@
 #include <QImage>
 #include <QPoint>
 #include <QPointF>
+#include <QTimer>
 
 #include <string>
 
@@ -49,6 +50,7 @@ public:
 
 	QPoint m_previousPos;
 	ViewOperationState m_viewOperationState;
+	QTimer m_timer;
 
 private:
 	TmsRegionSelectWidget* m_widget;

--- a/libs/guicore/tmsimage/tmsregionselectwidget.h
+++ b/libs/guicore/tmsimage/tmsregionselectwidget.h
@@ -43,6 +43,7 @@ public slots:
 
 private slots:
 	void handleImageUpdate(int requestId);
+	void handleTimer();
 
 private:
 	class Impl;


### PR DESCRIPTION
This closes #296, and #292 (a duplicate one).

The reason that iRIC crashes was that from the second time to open the dialog, TmsRegionSelectWidget::requestUpdate() goes into an infinite loop, and at last `new QWebView()` fails.

To avoid this, I added static variable `updating`.

Additionally, I've added Impl::m_timer to timeout after 10ms passed after the dialog is shown. Without this, from the second time, the map is not drawn on the window correctly. I know this is not a very good implementation but this works. I welcome suggestions about improving the implementation.

Thanks,

Keisuke Inoue