### PR TITLE
Closes i-RIC/prepost-gui#338

### DIFF
--- a/libs/geodata/pointmap/geodatapointmapwebimportersettingmanager.cpp
+++ b/libs/geodata/pointmap/geodatapointmapwebimportersettingmanager.cpp
@@ -26,7 +26,6 @@ std::vector<GeoDataPointmapWebImporterSetting> standardSettings()
 	ret.push_back(buildSetting(GeoDataPointmapWebImporterSettingManager::tr("GSI elevation tiles (DEM5A)"), 0, 15, "http://cyberjapandata.gsi.go.jp/xyz/dem5a/{z}/{x}/{y}.txt"));
 	ret.push_back(buildSetting(GeoDataPointmapWebImporterSettingManager::tr("GSI elevation tiles (DEM5B)"), 0, 15, "http://cyberjapandata.gsi.go.jp/xyz/dem5b/{z}/{x}/{y}.txt"));
 	ret.push_back(buildSetting(GeoDataPointmapWebImporterSettingManager::tr("GSI elevation tiles (DEM10B)"), 0, 14, "http://cyberjapandata.gsi.go.jp/xyz/dem/{z}/{x}/{y}.txt"));
-	ret.push_back(buildSetting(GeoDataPointmapWebImporterSettingManager::tr("GSI elevation tiles (Global Map ver. 2)"), 0, 8, "http://cyberjapandata.gsi.go.jp/xyz/demgm/{z}/{x}/{y}.txt"));
 
 	return ret;
 }


### PR DESCRIPTION
To test this pull request, please do the followings:

1. Open Preference dialog with menu "Option" -> "Preference"
2. Open "Web Elevation Data" tab
3. Click on "Restore Default" button.

With older iRIC GUI, you'll get 5 items, but after merging this pull request, you'll have 4 items, without "GSI elevation tiles (Global Map ver. 2)".