### PR TITLE
Closes i-RIC/prepost-gui#339

### DIFF
--- a/libs/geodata/pointmap/geodatapointmapwebimportersettingmanager.cpp
+++ b/libs/geodata/pointmap/geodatapointmapwebimportersettingmanager.cpp
@@ -22,7 +22,7 @@ std::vector<GeoDataPointmapWebImporterSetting> standardSettings()
 {
 	std::vector<GeoDataPointmapWebImporterSetting> ret;
 
-	ret.push_back(buildSetting(GeoDataPointmapWebImporterSettingManager::tr("USGS elevation tiles (SRTM)"), 0, 15, "https://earthexplorer.usgs.gov/wms/wmts/EPSG3857/srtm/{z}/{x}/{y}.csv"));
+	ret.push_back(buildSetting(GeoDataPointmapWebImporterSettingManager::tr("USGS elevation tiles (SRTM)"), 0, 13, "https://earthexplorer.usgs.gov/wms/wmts/EPSG3857/srtm/{z}/{x}/{y}.csv"));
 	ret.push_back(buildSetting(GeoDataPointmapWebImporterSettingManager::tr("GSI elevation tiles (DEM5A)"), 0, 15, "http://cyberjapandata.gsi.go.jp/xyz/dem5a/{z}/{x}/{y}.txt"));
 	ret.push_back(buildSetting(GeoDataPointmapWebImporterSettingManager::tr("GSI elevation tiles (DEM5B)"), 0, 15, "http://cyberjapandata.gsi.go.jp/xyz/dem5b/{z}/{x}/{y}.txt"));
 	ret.push_back(buildSetting(GeoDataPointmapWebImporterSettingManager::tr("GSI elevation tiles (DEM10B)"), 0, 14, "http://cyberjapandata.gsi.go.jp/xyz/dem/{z}/{x}/{y}.txt"));


### PR DESCRIPTION
To test this pull request, please do the followings:

1. Open Preference dialog with menu "Option" -> "Preference"
2. Open "Web Elevation Data" tab
3. Click on "Restore Default" button.
4. Click on "OK" button.

After doing above, please import elevation data, with "USGS elevation tiles (SRTM)". you'll see that the maximum zoom level is 13, not 15.