### PR TITLE
Closes i-RIC/prepost-gui#340

### DIFF
--- a/libs/dataitem/measureddata/measureddatafiledataitem.cpp
+++ b/libs/dataitem/measureddata/measureddatafiledataitem.cpp
@@ -22,6 +22,7 @@
 #include <QMessageBox>
 #include <QStandardItem>
 #include <QStatusBar>
+#include <QVector2D>
 #include <QXmlStreamWriter>
 
 MeasuredDataFileDataItem::Impl::Impl(MeasuredData* md) :
@@ -83,7 +84,9 @@ void MeasuredDataFileDataItem::exportToFile()
 
 	try {
 		MeasuredDataCsvExporter exporter;
-		exporter.exportData(fname, *(impl->m_measuredData));
+		QVector2D of = offset();
+		QPointF local_offset = QPointF(of.x(), of.y());
+		exporter.exportData(fname, local_offset, *(impl->m_measuredData));
 
 		iricMainWindow()->statusBar()->showMessage(tr("Measured Data successfully exported to %1.").arg(QDir::toNativeSeparators(fname)), iRICMainWindowInterface::STATUSBAR_DISPLAYTIME);
 	} catch (ErrorMessage& message) {

--- a/libs/guicore/project/measured/measureddatacsvexporter.cpp
+++ b/libs/guicore/project/measured/measureddatacsvexporter.cpp
@@ -11,7 +11,7 @@
 #include <vtkPointData.h>
 #include <vtkPolyData.h>
 
-void MeasuredDataCsvExporter::exportData(const QString& filename, const MeasuredData& data) const
+void MeasuredDataCsvExporter::exportData(const QString& filename, const QPointF& offset, const MeasuredData& data) const
 {
 	QFile file(filename);
 	if (! file.open(QFile::WriteOnly | QFile::Text)) {
@@ -53,8 +53,8 @@ void MeasuredDataCsvExporter::exportData(const QString& filename, const Measured
 		QVector<double> vals;
 		// output X, Y
 		double* p = vtkData->GetPoint(i);
-		vals << *(p);
-		vals << *(p + 1);
+		vals << *(p) + offset.x();
+		vals << *(p + 1) + offset.y();
 
 		// output scalar and vector data.
 		for (int j = 0; j < nArrays; ++j) {

--- a/libs/guicore/project/measured/measureddatacsvexporter.h
+++ b/libs/guicore/project/measured/measureddatacsvexporter.h
@@ -8,7 +8,7 @@
 class GUICOREDLL_EXPORT MeasuredDataCsvExporter : public MeasuredDataExporterI
 {
 public:
-	void exportData(const QString& filename, const MeasuredData& data) const override;
+	void exportData(const QString& filename, const QPointF& offset, const MeasuredData& data) const override;
 };
 
 #endif // MEASUREDDATACSVEXPORTER_H

--- a/libs/guicore/project/measured/measureddatacsvimporter.cpp
+++ b/libs/guicore/project/measured/measureddatacsvimporter.cpp
@@ -7,6 +7,7 @@
 #include <QDir>
 #include <QFile>
 #include <QList>
+#include <QPointF>
 #include <QTextCodec>
 #include <QTextStream>
 
@@ -33,7 +34,7 @@ struct VectorData {
 
 } // namespace
 
-MeasuredData* MeasuredDataCsvImporter::importData(const QString &filename, ProjectDataItem* parent) const
+MeasuredData* MeasuredDataCsvImporter::importData(const QString &filename, const QPointF& offset, ProjectDataItem* parent) const
 {
 	MeasuredData* ret = new MeasuredData(parent);
 
@@ -146,9 +147,9 @@ MeasuredData* MeasuredDataCsvImporter::importData(const QString &filename, Proje
 		ret->pointData()->GetPointData()->AddArray(da);
 		da->Delete();
 	}
-
 	ret->setName(QDir::toNativeSeparators(filename));
 	ret->setupPolyData();
+	ret->applyOffset(offset.x(), offset.y());
 
 	return ret;
 }

--- a/libs/guicore/project/measured/measureddatacsvimporter.h
+++ b/libs/guicore/project/measured/measureddatacsvimporter.h
@@ -6,7 +6,7 @@
 class MeasuredDataCsvImporter : public MeasuredDataImporterI
 {
 public:
-	MeasuredData* importData(const QString &filename, ProjectDataItem* parent) const override;
+	MeasuredData* importData(const QString &filename, const QPointF& offset, ProjectDataItem* parent) const override;
 };
 
 #endif // MEASUREDDATACSVIMPORTER_H

--- a/libs/guicore/project/measured/measureddataexporteri.h
+++ b/libs/guicore/project/measured/measureddataexporteri.h
@@ -3,12 +3,14 @@
 
 class MeasuredData;
 
+class QPointF;
+
 class MeasuredDataExporterI
 {
 public:
 	virtual ~MeasuredDataExporterI() {}
 
-	virtual void exportData(const QString& filename, const MeasuredData& data) const = 0;
+	virtual void exportData(const QString& filename, const QPointF& offset, const MeasuredData& data) const = 0;
 };
 
 

--- a/libs/guicore/project/measured/measureddataimporteri.h
+++ b/libs/guicore/project/measured/measureddataimporteri.h
@@ -4,12 +4,14 @@
 class MeasuredData;
 class ProjectDataItem;
 
+class QPointF;
+
 class MeasuredDataImporterI
 {
 public:
 	virtual ~MeasuredDataImporterI() {}
 
-	virtual MeasuredData* importData(const QString& filename, ProjectDataItem* parent) const = 0;
+	virtual MeasuredData* importData(const QString& filename, const QPointF& offset, ProjectDataItem* parent) const = 0;
 };
 
 #endif // MEASUREDDATAIMPORTERI_H

--- a/libs/guicore/project/projectmainfile.cpp
+++ b/libs/guicore/project/projectmainfile.cpp
@@ -1018,7 +1018,9 @@ void ProjectMainFile::addMeasuredData()
 	QFileInfo finfo(fname);
 	try {
 		MeasuredDataCsvImporter importer;
-		MeasuredData* md = importer.importData(fname, this);
+		QVector2D of = offset();
+		QPointF local_offset = QPointF(of.x(), of.y());
+		MeasuredData* md = importer.importData(fname, local_offset, this);
 		impl->m_measuredDatas.push_back(md);
 		emit measuredDataAdded();
 		setModified();


### PR DESCRIPTION
To test this, please do the followings:

1. Start new project
2. From "File" -> "Property" menu, edit "Coordinate Offset" value, to (10000, 20000), for example.
3. Import the measured.txt attached with this pull request.

From the values in status bar, you can know the coordinates of points imported to "Measured Values". with old iRIC, the coordinates will be (10000, 20000), etc., but after merging this, the coordinates will be (0, 0), etc.

4. From "File" -> "Property" menu, edit "Coordinate Offset" value, to (20000, 60000), for example.
5. In the Object browser, select the node for the data you've imported ("C:\Users\...\Desktop\measured.txt", for example), and select "Export" from right-clicking menu.
6. Specify file name to save the measured data to a file.

With old iRIC GUI, the coordinates in the CSV file will be (-10000, -40000) etc., but after merging this, the coordinates will be (0, 0).

[measured.txt](https://github.com/i-RIC/prepost-gui/files/2092706/measured.txt)
