### PR TITLE
Closes i-RIC/prepost-gui#78

### DIFF
--- a/libs/cs/coordinatesystem.cpp
+++ b/libs/cs/coordinatesystem.cpp
@@ -105,3 +105,8 @@ void CoordinateSystem::mapGridToGeo(double fromX, double fromY, double* toX, dou
 		*toY = fromY;
 	}
 }
+
+bool CoordinateSystem::isLongLat() const
+{
+	return impl->m_proj4PlaneStr.contains("+proj=longlat");
+}

--- a/libs/cs/coordinatesystem.h
+++ b/libs/cs/coordinatesystem.h
@@ -29,6 +29,8 @@ public:
 	void mapGeoToGrid(double fromX, double fromY, double* toX, double* toY) const;
 	void mapGridToGeo(double fromX, double fromY, double* toX, double* toY) const;
 
+	bool isLongLat() const;
+
 private:
 	class Impl;
 	Impl* impl;

--- a/libs/cs/cs.pro
+++ b/libs/cs/cs.pro
@@ -43,6 +43,15 @@ unix {
 	LIBS += -lproj
 }
 
+# GDAL
+
+win32 {
+	LIBS += -lgdal_i
+}
+unix {
+	LIBS += -lgdal
+}
+
 # Post-Build Event
 win32 {
 	QMAKE_POST_LINK += copy $(TargetPath) $(SolutionDir)\\libdlls\\$(Configuration)

--- a/libs/cs/webmercatorutil.cpp
+++ b/libs/cs/webmercatorutil.cpp
@@ -11,6 +11,7 @@
 #include <QString>
 
 #include <gdal_priv.h>
+#include <proj_api.h>
 
 #define _USE_MATH_DEFINES
 #include <math.h>

--- a/libs/cs/webmercatorutil.cpp
+++ b/libs/cs/webmercatorutil.cpp
@@ -1,16 +1,100 @@
+#include "coordinatesystem.h"
 #include "webmercatorutil.h"
 #include "private/webmercatorutil_impl.h"
 
+#include <misc/iricrootpath.h>
+#include <misc/stringtool.h>
+
+#include <QDir>
+#include <QImage>
+#include <QProcess>
 #include <QString>
+
+#include <gdal_priv.h>
 
 #define _USE_MATH_DEFINES
 #include <math.h>
 #include <cmath>
+#include <vector>
 
 namespace {
 
-double DEG_TO_RAD = M_PI / 180;
-double RAD_TO_DEG = 180 / M_PI;
+const char* EPSG3857STR = "PROJCS[\"WGS 84 / Pseudo-Mercator\",GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]],PROJECTION[\"Mercator_1SP\"],PARAMETER[\"central_meridian\",0],PARAMETER[\"scale_factor\",1],PARAMETER[\"false_easting\",0],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]],AXIS[\"X\",EAST],AXIS[\"Y\",NORTH],EXTENSION[\"PROJ4\",\"+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext  +no_defs\"],AUTHORITY[\"EPSG\",\"3857\"]]";
+const char* EPSG4326STR = "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]";
+
+CoordinateSystem webMercatorCS("WebMercator", "WebMercator",
+															 "+proj=latlong +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0", "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs");
+
+
+bool saveGeoTIFF(const std::string& fname, const QRectF& rect, const QImage& img)
+{
+	QImage rgbImg = img.convertToFormat(QImage::Format_RGB888);
+
+	GDALDriver* driver = GetGDALDriverManager()->GetDriverByName("GTiff");
+	char** options = NULL;
+	GDALDataset *ds = driver->Create(fname.c_str(), rgbImg.width(), rgbImg.height(), 3, GDT_Byte, options);
+	if (ds == NULL) { return false; }
+
+	int bitCount = rgbImg.width() * rgbImg.height();
+	std::vector<unsigned char> rBits, gBits, bBits;
+	rBits.assign(bitCount, 0);
+	gBits.assign(bitCount, 0);
+	bBits.assign(bitCount, 0);
+
+	for (int i = 0; i < rgbImg.height(); ++i) {
+		const uchar* head = rgbImg.scanLine(i);
+		for (int j = 0; j < rgbImg.width(); ++j) {
+			int idx = j + i * rgbImg.width();
+			rBits[idx] = *(head + j * 3);
+			gBits[idx] = *(head + j * 3 + 1);
+			bBits[idx] = *(head + j * 3 + 2);
+		}
+	}
+	GDALRasterBand* band = nullptr;
+	band = ds->GetRasterBand(1);
+	band->RasterIO(GF_Write, 0, 0, rgbImg.width(), rgbImg.height(), (void*)(rBits.data()),
+		rgbImg.width(), rgbImg.height(), GDT_Byte, 1, rgbImg.width());
+	band = ds->GetRasterBand(2);
+	band->RasterIO(GF_Write, 0, 0, rgbImg.width(), rgbImg.height(), (void*)(gBits.data()),
+		rgbImg.width(), rgbImg.height(), GDT_Byte, 1, rgbImg.width());
+	band = ds->GetRasterBand(3);
+	band->RasterIO(GF_Write, 0, 0, rgbImg.width(), rgbImg.height(), (void*)(bBits.data()),
+		rgbImg.width(), rgbImg.height(), GDT_Byte, 1, rgbImg.width());
+
+	double xmin, ymax, xmax;
+	webMercatorCS.init();
+	webMercatorCS.mapGeoToGrid(rect.left(), rect.bottom(), &xmin, &ymax);
+	webMercatorCS.mapGeoToGrid(rect.right(), rect.bottom(), &xmax, &ymax);
+	double delta = (xmax - xmin) / img.width();
+
+	double transform[6] = { xmin, delta, 0, ymax, 0, -delta };
+	ds->SetGeoTransform(transform);
+
+	ds->SetProjection(EPSG3857STR);
+	GDALClose(static_cast<GDALDatasetH> (ds));
+
+	return true;
+}
+
+bool convertGeoTiffToLongLat(const std::string& from, const std::string& to, double res)
+{
+	QString exepath = iRICRootPath::get();
+	QString exeName = QDir(exepath).absoluteFilePath("gdalwarp.exe");
+	QString resstr = QString::number(res, 'g', 10);
+
+	QStringList args;
+	args << "-s_srs" << EPSG3857STR << "-t_srs" << EPSG4326STR;
+	args << from.c_str() << to.c_str();
+
+	int ret = QProcess::execute(exeName, args);
+	return (ret == 0);
+}
+
+bool loadGeoTIFF(const std::string& fname, QImage* img)
+{
+	*img = QImage(fname.c_str());
+	return true;
+}
 
 } // namespace
 
@@ -76,4 +160,55 @@ void WebMercatorUtil::getTileRegion(double topLeftLon, double topLeftLat, double
 	*yMin = static_cast<int>(std::floor(ymin));
 	*xMax = static_cast<int>(std::ceil(xmax));
 	*yMax = static_cast<int>(std::ceil(ymax));
+}
+
+
+void WebMercatorUtil::calcImageZoomAndSize(double lonMin, double latMin, double lonMax, double latMax, double imgWidth,
+																					 double* lonCenter, double* latCenter, int* zoomLevel, int* width, int* height)
+{
+	double xmin, ymin, xmax, ymax, xcenter, ycenter;
+
+	Impl impl;
+	impl.init(0);
+
+	impl.project_plxel(lonMin, latMin, &xmin, &ymin);
+	impl.project_plxel(lonMax, latMax, &xmax, &ymax);
+
+	xcenter = (xmin + xmax) * 0.5;
+	ycenter = (ymin + ymax) * 0.5;
+	impl.unproject_pixel(xcenter, ycenter, lonCenter, latCenter);
+
+	double xwidth = qAbs(xmax - xmin);
+	double ywidth = qAbs(ymax - ymin);
+	*zoomLevel = 0;
+	while (xwidth < imgWidth) {
+		*zoomLevel += 1;
+		xwidth *= 2;
+		ywidth *= 2;
+	}
+	*width = static_cast<int> (xwidth);
+	*height = static_cast<int> (ywidth);
+}
+
+QImage WebMercatorUtil::convertWebMercatorToLongLat(const QRectF& rect, const QImage& image, const QString& workDir)
+{
+	static int idx = 0;
+	GDALAllRegister();
+
+	QDir dir(workDir);
+	std::string tmpImg1 = iRIC::toStr(dir.absoluteFilePath(QString("img%1.tif").arg(++idx)));
+	std::string tmpImg2 = iRIC::toStr(dir.absoluteFilePath(QString("img%1.tif").arg(++idx)));
+
+	bool ok = saveGeoTIFF(tmpImg1, rect, image);
+	ok = convertGeoTiffToLongLat(tmpImg1, tmpImg2, rect.width() / image.width());
+	QImage result;
+	ok = loadGeoTIFF(tmpImg2, &result);
+	QFile::remove(tmpImg1.c_str());
+	QFile::remove(tmpImg2.c_str());
+
+	int w = image.width();
+	int h = static_cast<double>(result.height()) / result.width() * w;
+	result = result.scaled(w, h);
+
+	return result;
 }

--- a/libs/cs/webmercatorutil.h
+++ b/libs/cs/webmercatorutil.h
@@ -5,6 +5,9 @@
 
 class CoordinateSystem;
 
+class QImage;
+class QRectF;
+
 class CS_API WebMercatorUtil
 {
 public:
@@ -13,6 +16,11 @@ public:
 
 	void getCoordinates(int tilex, int tiley, int pixelx, int pixely, double* lon, double* lat);
 	void getTileRegion(double topLeftLon, double topLeftLat, double bottomRightLon, double bottomRightLat, int* xMin, int* xMax, int* yMin, int *yMax);
+
+	static void calcImageZoomAndSize(double lonMin, double latMin, double lonMax, double latMax, double imgWidth,
+															double* lonCenter, double* latCenter, int* zoomLevel, int* width, int* height);
+
+	static QImage convertWebMercatorToLongLat(const QRectF& rect, const QImage& image, const QString& workDir);
 
 private:
 	class Impl;


### PR DESCRIPTION
## Abstract

After merging this pull request, Web background image works correctly with Longitude-latitude coordinate system, like WGS 84 (EPSG:4326).

## Preparation

When testing this pull request, please note that you have to copy gdalwarp.exe to the path where iRIC.exe exists. gdalwarp.exe can be copyed from `iricdev/lib/install/gdal-1.11.2/release/bin`.

## How to test

1. Start new project
2. Open File -> Property
3. Edit [Coordinate System] to "EPSG:4326: WGS 84", and click on [OK]
4. Check on one of "Background Images (Internet)" child item, like "Google Map (Road)".

Then, image like below will be shown, around Japan.

![image1](https://user-images.githubusercontent.com/4031569/41392521-0aa46556-6fdc-11e8-9577-6760237da1c5.png)

Please compare with the image below, that is shown with Coordinate System "EPSG:2450". You'll see that because it is converted with gdalwarp, Japan is compressed in vertical direction.

![image2](https://user-images.githubusercontent.com/4031569/41392527-17604422-6fdc-11e8-82c7-a584539899c2.png)

## About limitation

We can not get background image over Longitude 180 degree line. Please see the images below.

![image3](https://user-images.githubusercontent.com/4031569/41392529-22b04a20-6fdc-11e8-860c-dbad7c7714e5.png)

![image4](https://user-images.githubusercontent.com/4031569/41392534-2d76ced4-6fdc-11e8-92bd-0b933849fdf4.png)
