### PR TITLE
Closes i-RIC/prepost-gui#189

### DIFF
--- a/libs/misc/informationdialog.cpp
+++ b/libs/misc/informationdialog.cpp
@@ -54,6 +54,7 @@ void InformationDialog::showDialog(QWidget* parent, const QString& title, const 
 	dialog.setWindowTitle(title);
 	dialog.setMessage(message);
 	dialog.setIcon(pixmap);
+	dialog.resize(450, dialog.minimumHeight());
 	dialog.exec();
 	dontshowagain = dialog.dontShowAgain();
 	settings.setValue(fullname, dontshowagain);


### PR DESCRIPTION
Message on Information is visible with this fix.
I've tried to fix by code:
```
dialog.resize(dialog.minimumSize())
```
But this resulted to make the dialog width too small. That's why I'm using 450 for width.