### PR TITLE
Refactoring: ProjectMainFile::renderers()

### DIFF
--- a/libs/guicore/project/projectmainfile.cpp
+++ b/libs/guicore/project/projectmainfile.cpp
@@ -719,7 +719,7 @@ const std::vector<MeasuredData*>& ProjectMainFile::measuredDatas() const
 	return impl->m_measuredDatas;
 }
 
-const QList<vtkRenderer*>& ProjectMainFile::renderers() const
+const std::vector<vtkRenderer*>& ProjectMainFile::renderers() const
 {
 	return m_renderers;
 }
@@ -941,10 +941,10 @@ void ProjectMainFile::moveDownMeasuredData(const QModelIndex& index)
 
 void ProjectMainFile::addRenderer(vtkRenderer* ren)
 {
-	for (auto it = m_renderers.begin(); it != m_renderers.end(); ++it) {
-		if (*it == ren) { return; }
+	for (vtkRenderer* r : m_renderers) {
+		if (r == ren) {return;}
 	}
-	m_renderers.append(ren);
+	m_renderers.push_back(ren);
 }
 
 void ProjectMainFile::clearModified()

--- a/libs/guicore/project/projectmainfile.h
+++ b/libs/guicore/project/projectmainfile.h
@@ -95,7 +95,7 @@ public:
 	/// Measured data
 	const std::vector<MeasuredData*>& measuredDatas() const;
 	/// Renderers for background images
-	const QList<vtkRenderer*>& renderers() const;
+	const std::vector<vtkRenderer*>& renderers() const;
 
 	void updateActorVisibility(int idx, bool vis);
 	bool importCgnsFile(const QString& filename, const QString& newname);
@@ -163,7 +163,7 @@ private:
 	/// ProjectData
 	ProjectData* m_projectData;
 	/// Renderers for background images
-	QList<vtkRenderer*> m_renderers;
+	std::vector<vtkRenderer*> m_renderers;
 	/// Load data from CGNS file
 	bool loadCgnsFile(const QString& name);
 	/// Soad data from CGNS file


### PR DESCRIPTION
Changed from QList<vtkRenderer*> to std::vector<vtkRenderer*>.

The reason is that we can see the content of std::vector using Visual Studio, but with QList, we can not.
We still have many QList code in iRIC GUI, and I will migrate gradually when I have time.