### PR TITLE
Closes i-RIC/prepost-gui#401

### DIFF
--- a/libs/gridcreatingcondition/externalprogram/gridcreatingconditionexternalprogram.cpp
+++ b/libs/gridcreatingcondition/externalprogram/gridcreatingconditionexternalprogram.cpp
@@ -121,7 +121,6 @@ bool GridCreatingConditionExternalProgram::create(QWidget* /*parent*/)
 	SolverDefinitionGridType* gType = gtItem->gridType();
 	// Create grid.
 	Grid* grid = gType->createEmptyGrid();
-	gType->buildGridAttributes(grid);
 
 	// load create grid from cgnsfile. it is always loaded from the first zone in the first base.
 	int fn;


### PR DESCRIPTION
The following line calls buildGridAttributes() inside, so this creates duplicate grid attributes().
```
Grid* grid = gType->createEmptyGrid();
```
