### PR TITLE
Appveyor build

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+## prepost-gui [![Build status](https://ci.appveyor.com/api/projects/status/f5lfc0iym90xpb7b?svg=true)](https://ci.appveyor.com/project/i-RIC/prepost-gui)
+
+The paths to install external libraries, such as VTK, Qwt, proj.4 differs on each development environment, so the 
+paths are now excluded from src.pro, and stored in paths.pri.
+
+This folder contains paths_std.pri, so copy it to paths.pri, and modify it to fit your environment. Or use the
+paths.pri that's created when building https://github.com/i-RIC/iricdev (or by running create-files.cmd).

--- a/README.txt
+++ b/README.txt
@@ -1,6 +1,0 @@
-README.txt
-
-The paths to install external libraries, such as VTK, Qwt, proj.4 differs on each development environment, so the 
-paths are now excluded from src.pro, and stored in paths.pri.
-
-This folder contains paths_std.pri, so copy it to paths.pri, and modify it to fit your environment.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,8 +23,10 @@ before_build:
   - call "C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\vcvarsall.bat" x86_amd64
   - cd %APPVEYOR_BUILD_FOLDER%
   - curl -L -O https://github.com/i-RIC/iricdev/archive/master.zip
-  - 7z x master.zip
-  - cd iricdev-master
+  - cd \
+  - 7z x %APPVEYOR_BUILD_FOLDER%\master.zip
+  - del %APPVEYOR_BUILD_FOLDER%\master.zip
+  - cd \iricdev-master
   - md lib
   - cd lib
   - ps: (New-Object Net.WebClient).DownloadFile("https://ci.appveyor.com/api/projects/i-RIC/iricdev/artifacts/lib/install.zip?branch=master&job=Configuration:+Debug", "$Env:APPVEYOR_BUILD_FOLDER\iricdev-master\lib\install-Debug.zip")
@@ -33,18 +35,23 @@ before_build:
   - cd install
   - 7z x -aoa ..\install-Debug.zip
   - 7z x -aoa ..\install-Release.zip
-  - cd %APPVEYOR_BUILD_FOLDER%\iricdev-master
+  - cd \iricdev-master
   - call create-files.cmd
   - cd %APPVEYOR_BUILD_FOLDER%
   - if not exist libdlls (md libdlls)
   - if not exist libdlls\Debug (md libdlls\Debug)
   - if not exist libdlls\Release (md libdlls\Release)
-  - copy /y .\iricdev-master\paths.pri .
-  - copy /y .\iricdev-master\dirExt.prop .\tools\data\.
+  - copy /y \iricdev-master\paths.pri .
+  - copy /y \iricdev-master\dirExt.prop .\tools\data\.
   - qmake -recursive -tp vc
 
 build_script:
   - msbuild /nologo /verbosity:minimal /p:Configuration=%Configuration% src.sln
+
+after_build:
+  - cd %APPVEYOR_BUILD_FOLDER%\tools
+  - python copydllsExt.py
+  - cd %APPVEYOR_BUILD_FOLDER%
 
 artifacts:
   - path: libdlls\$(Configuration)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,8 +29,8 @@ before_build:
   - cd \iricdev-master
   - md lib
   - cd lib
-  - ps: (New-Object Net.WebClient).DownloadFile("https://ci.appveyor.com/api/projects/i-RIC/iricdev/artifacts/lib/install.zip?branch=master&job=Configuration:+Debug", "$Env:APPVEYOR_BUILD_FOLDER\iricdev-master\lib\install-Debug.zip")
-  - ps: (New-Object Net.WebClient).DownloadFile("https://ci.appveyor.com/api/projects/i-RIC/iricdev/artifacts/lib/install.zip?branch=master&job=Configuration:+Release", "$Env:APPVEYOR_BUILD_FOLDER\iricdev-master\lib\install-Release.zip")
+  - ps: (New-Object Net.WebClient).DownloadFile("https://ci.appveyor.com/api/projects/i-RIC/iricdev/artifacts/lib/install.zip?branch=master&job=Configuration:+Debug", "\iricdev-master\lib\install-Debug.zip")
+  - ps: (New-Object Net.WebClient).DownloadFile("https://ci.appveyor.com/api/projects/i-RIC/iricdev/artifacts/lib/install.zip?branch=master&job=Configuration:+Release", "\iricdev-master\lib\install-Release.zip")
   - md install
   - cd install
   - 7z x -aoa ..\install-Debug.zip
@@ -55,4 +55,6 @@ after_build:
 
 artifacts:
   - path: libdlls\$(Configuration)
+    name: libdlls-$(Configuration)
   - path: apps\iricgui\$(config)
+    name: iricgui-$(Configuration)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -46,7 +46,7 @@ before_build:
   - qmake -recursive -tp vc
 
 build_script:
-  - echo msbuild /nologo /verbosity:minimal /p:Configuration=%Configuration% src.sln
+  - msbuild /nologo /verbosity:minimal /p:Configuration=%Configuration% src.sln
 
 after_build:
   - cd %APPVEYOR_BUILD_FOLDER%\tools

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,8 +26,8 @@ before_build:
   - cd iricdev-master
   - md lib
   - cd lib
-  - echo curl -L -o install.zip "https://ci.appveyor.com/api/projects/i-RIC/iricdev/artifacts/lib/install.zip?branch=master&job=Configuration%3A+"%Configuration%
-  - curl -L -o install.zip "https://ci.appveyor.com/api/projects/i-RIC/iricdev/artifacts/lib/install.zip?branch=master&job=Configuration%3A+"%Configuration%
+  - echo curl -fsSL -o install.zip "https://ci.appveyor.com/api/projects/i-RIC/iricdev/artifacts/lib/install.zip?branch=master&job=Configuration%3A+"%Configuration%
+  - curl -fsSL -o install.zip "https://ci.appveyor.com/api/projects/i-RIC/iricdev/artifacts/lib/install.zip?branch=master&job=Configuration%3A+"%Configuration%
   - md install
   - cd install
   - 7z x ..\install.zip

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,10 +26,7 @@ before_build:
   - cd iricdev-master
   - md lib
   - cd lib
-  - echo appveyor downloadfile "https://ci.appveyor.com/api/projects/i-RIC/iricdev/artifacts/lib/install.zip?branch=master&job=Configuration%3A+%Configuration%" -FileName install.zip
-  - appveyor downloadfile "https://ci.appveyor.com/api/projects/i-RIC/iricdev/artifacts/lib/install.zip?branch=master&job=Configuration%3A+%Configuration%" -FileName install.zip
-  - REM echo curl -fsSL -o install.zip "https://ci.appveyor.com/api/projects/i-RIC/iricdev/artifacts/lib/install.zip?branch=master&job=Configuration%3A+%Configuration%"
-  - REM curl -fsSL -o install.zip "https://ci.appveyor.com/api/projects/i-RIC/iricdev/artifacts/lib/install.zip?branch=master&job=Configuration%3A+%Configuration%"
+  - ps: (New-Object Net.WebClient).DownloadFile("https://ci.appveyor.com/api/projects/i-RIC/iricdev/artifacts/lib/install.zip?branch=master&job=Configuration: $Env:Configuration", "$Env:APPVEYOR_BUILD_FOLDER\iricdev-master\lib\install.zip")
   - md install
   - cd install
   - 7z x ..\install.zip

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,8 +26,8 @@ before_build:
   - cd iricdev-master
   - md lib
   - cd lib
-  - echo curl -L -o install.zip "https://ci.appveyor.com/api/projects/i-RIC/iricdev/artifacts/lib/install.zip?branch=master&job=Configuration%3A+%Configuration%"
-  - curl -L -o install.zip "https://ci.appveyor.com/api/projects/i-RIC/iricdev/artifacts/lib/install.zip?branch=master&job=Configuration%3A+%Configuration%"
+  - echo curl -L -o install.zip "https://ci.appveyor.com/api/projects/i-RIC/iricdev/artifacts/lib/install.zip?branch=master&job=Configuration%%3A+%Configuration%"
+  - curl -L -o install.zip "https://ci.appveyor.com/api/projects/i-RIC/iricdev/artifacts/lib/install.zip?branch=master&job=Configuration%%3A+%Configuration%"
   - md install
   - cd install
   - 7z x ..\install.zip

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,10 @@
 version: '{build}'
 
+# Skipping commits affecting specific files (GitHub only).
+skip_commits:
+  files:
+    - README.md
+
 image: Visual Studio 2013
 
 # called before clone

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -46,11 +46,14 @@ before_build:
   - qmake -recursive -tp vc
 
 build_script:
-  - msbuild /nologo /verbosity:minimal /p:Configuration=%Configuration% src.sln
+  - echo msbuild /nologo /verbosity:minimal /p:Configuration=%Configuration% src.sln
 
 after_build:
   - cd %APPVEYOR_BUILD_FOLDER%\tools
+  - set SAVE_PATH=%PATH%
+  - set PATH=C:\Python37-x64;%PATH%
   - python copydllsExt.py
+  - set PATH=%SAVE_PATH%
   - cd %APPVEYOR_BUILD_FOLDER%
 
 artifacts:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,10 +26,12 @@ before_build:
   - cd iricdev-master
   - md lib
   - cd lib
-  - ps: (New-Object Net.WebClient).DownloadFile("https://ci.appveyor.com/api/projects/i-RIC/iricdev/artifacts/lib/install.zip?branch=master&job=Configuration:+$Env:Configuration", "$Env:APPVEYOR_BUILD_FOLDER\iricdev-master\lib\install.zip")
+  - ps: (New-Object Net.WebClient).DownloadFile("https://ci.appveyor.com/api/projects/i-RIC/iricdev/artifacts/lib/install.zip?branch=master&job=Configuration:+Debug", "$Env:APPVEYOR_BUILD_FOLDER\iricdev-master\lib\install-Debug.zip")
+  - ps: (New-Object Net.WebClient).DownloadFile("https://ci.appveyor.com/api/projects/i-RIC/iricdev/artifacts/lib/install.zip?branch=master&job=Configuration:+Release", "$Env:APPVEYOR_BUILD_FOLDER\iricdev-master\lib\install-Release.zip")
   - md install
   - cd install
-  - 7z x ..\install.zip
+  - 7z x -aoa ..\install-Debug.zip
+  - 7z x -aoa ..\install-Release.zip
   - cd %APPVEYOR_BUILD_FOLDER%\iricdev-master
   - call create-files.cmd
   - cd %APPVEYOR_BUILD_FOLDER%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,43 @@
+version: '{build}'
+
+image: Visual Studio 2013
+
+# called before clone
+init:
+  - echo %APPVEYOR_BUILD_WORKER_IMAGE%
+
+configuration:
+  - Debug
+  - Release
+
+matrix:
+  fast_finish: true
+
+# Note mkdir is from Git (C:\Program Files\Git\usr\bin\mkdir.exe)
+# It might give unexpected results (use md instead)call create-files.cmd
+before_build:
+  - call C:\Qt\5.5\msvc2013_64\bin\qtenv2.bat
+  - call "C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\vcvarsall.bat" x86_amd64
+  - cd %APPVEYOR_BUILD_FOLDER%
+  - curl -L -O https://github.com/i-RIC/iricdev/archive/master.zip
+  - 7z x master.zip
+  - cd iricdev-master
+  - md lib
+  - cd lib
+  - curl -L -o install.zip "https://ci.appveyor.com/api/projects/i-RIC/iricdev/artifacts/lib/install.zip?branch=master&job=Configuration%3A+%Configuration%"
+  - md install
+  - cd install
+  - 7z x ..\install.zip
+  - cd %APPVEYOR_BUILD_FOLDER%\iricdev-master
+  - call create-files.cmd
+  - cd %APPVEYOR_BUILD_FOLDER%
+  - if not exist libdlls (md libdlls)
+  - if not exist libdlls\Debug (md libdlls\Debug)
+  - if not exist libdlls\Release (md libdlls\Release)
+  - copy /y .\iricdev-master\paths.pri .
+  - copy /y .\iricdev-master\dirExt.prop .\tools\data\.
+  - qmake -recursive -tp vc
+
+# build using cmake tools
+build_script:
+  - msbuild /nologo /verbosity:minimal /p:Configuration=%Configuration% src.sln

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,6 +6,8 @@ image: Visual Studio 2013
 init:
   - echo %APPVEYOR_BUILD_WORKER_IMAGE%
   - echo %Configuration%
+  - if "%Configuration%"=="Debug"   (set config=debug)
+  - if "%Configuration%"=="Release" (set config=release)
 
 configuration:
   - Debug
@@ -15,12 +17,11 @@ matrix:
   fast_finish: true
 
 # Note mkdir is from Git (C:\Program Files\Git\usr\bin\mkdir.exe)
-# It might give unexpected results (use md instead)call create-files.cmd
+# It might give unexpected results (use md instead)
 before_build:
   - call C:\Qt\5.5\msvc2013_64\bin\qtenv2.bat
   - call "C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\vcvarsall.bat" x86_amd64
   - cd %APPVEYOR_BUILD_FOLDER%
-  - echo curl -L -O https://github.com/i-RIC/iricdev/archive/master.zip
   - curl -L -O https://github.com/i-RIC/iricdev/archive/master.zip
   - 7z x master.zip
   - cd iricdev-master
@@ -42,6 +43,9 @@ before_build:
   - copy /y .\iricdev-master\dirExt.prop .\tools\data\.
   - qmake -recursive -tp vc
 
-# build using cmake tools
 build_script:
   - msbuild /nologo /verbosity:minimal /p:Configuration=%Configuration% src.sln
+
+artifacts:
+  - path: libdlls\$(Configuration)
+  - path: apps\iricgui\$(config)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,6 +5,7 @@ image: Visual Studio 2013
 # called before clone
 init:
   - echo %APPVEYOR_BUILD_WORKER_IMAGE%
+  - echo %Configuration%
 
 configuration:
   - Debug
@@ -19,11 +20,13 @@ before_build:
   - call C:\Qt\5.5\msvc2013_64\bin\qtenv2.bat
   - call "C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\vcvarsall.bat" x86_amd64
   - cd %APPVEYOR_BUILD_FOLDER%
+  - echo curl -L -O https://github.com/i-RIC/iricdev/archive/master.zip
   - curl -L -O https://github.com/i-RIC/iricdev/archive/master.zip
   - 7z x master.zip
   - cd iricdev-master
   - md lib
   - cd lib
+  - echo curl -L -o install.zip "https://ci.appveyor.com/api/projects/i-RIC/iricdev/artifacts/lib/install.zip?branch=master&job=Configuration%3A+%Configuration%"
   - curl -L -o install.zip "https://ci.appveyor.com/api/projects/i-RIC/iricdev/artifacts/lib/install.zip?branch=master&job=Configuration%3A+%Configuration%"
   - md install
   - cd install

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,8 +26,10 @@ before_build:
   - cd iricdev-master
   - md lib
   - cd lib
-  - echo curl -fsSL -o install.zip "https://ci.appveyor.com/api/projects/i-RIC/iricdev/artifacts/lib/install.zip?branch=master&job=Configuration%3A+"%Configuration%
-  - curl -fsSL -o install.zip "https://ci.appveyor.com/api/projects/i-RIC/iricdev/artifacts/lib/install.zip?branch=master&job=Configuration%3A+"%Configuration%
+  - echo appveyor downloadfile "https://ci.appveyor.com/api/projects/i-RIC/iricdev/artifacts/lib/install.zip?branch=master&job=Configuration%3A+%Configuration%" -FileName install.zip
+  - appveyor downloadfile "https://ci.appveyor.com/api/projects/i-RIC/iricdev/artifacts/lib/install.zip?branch=master&job=Configuration%3A+%Configuration%" -FileName install.zip
+  - REM echo curl -fsSL -o install.zip "https://ci.appveyor.com/api/projects/i-RIC/iricdev/artifacts/lib/install.zip?branch=master&job=Configuration%3A+%Configuration%"
+  - REM curl -fsSL -o install.zip "https://ci.appveyor.com/api/projects/i-RIC/iricdev/artifacts/lib/install.zip?branch=master&job=Configuration%3A+%Configuration%"
   - md install
   - cd install
   - 7z x ..\install.zip

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,8 +26,8 @@ before_build:
   - cd iricdev-master
   - md lib
   - cd lib
-  - echo curl -L -o install.zip "https://ci.appveyor.com/api/projects/i-RIC/iricdev/artifacts/lib/install.zip?branch=master&job=Configuration%%3A+%Configuration%"
-  - curl -L -o install.zip "https://ci.appveyor.com/api/projects/i-RIC/iricdev/artifacts/lib/install.zip?branch=master&job=Configuration%%3A+%Configuration%"
+  - echo curl -L -o install.zip "https://ci.appveyor.com/api/projects/i-RIC/iricdev/artifacts/lib/install.zip?branch=master&job=Configuration%3A+"%Configuration%
+  - curl -L -o install.zip "https://ci.appveyor.com/api/projects/i-RIC/iricdev/artifacts/lib/install.zip?branch=master&job=Configuration%3A+"%Configuration%
   - md install
   - cd install
   - 7z x ..\install.zip

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,7 +26,7 @@ before_build:
   - cd iricdev-master
   - md lib
   - cd lib
-  - appveyor DowloadFile "https://ci.appveyor.com/api/projects/i-RIC/iricdev/artifacts/lib/install.zip?branch=master&job=Configuration: %Configuration%" -FileName "install.zip"
+  - ps: (New-Object Net.WebClient).DownloadFile("https://ci.appveyor.com/api/projects/i-RIC/iricdev/artifacts/lib/install.zip?branch=master&job=Configuration:+$Env:Configuration", "$Env:APPVEYOR_BUILD_FOLDER\iricdev-master\lib\install.zip")
   - md install
   - cd install
   - 7z x ..\install.zip

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,7 +26,7 @@ before_build:
   - cd iricdev-master
   - md lib
   - cd lib
-  - ps: (New-Object Net.WebClient).DownloadFile("https://ci.appveyor.com/api/projects/i-RIC/iricdev/artifacts/lib/install.zip?branch=master&job=Configuration: $Env:Configuration", "$Env:APPVEYOR_BUILD_FOLDER\iricdev-master\lib\install.zip")
+  - appveyor DowloadFile "https://ci.appveyor.com/api/projects/i-RIC/iricdev/artifacts/lib/install.zip?branch=master&job=Configuration: %Configuration%" -FileName "install.zip"
   - md install
   - cd install
   - 7z x ..\install.zip

--- a/tools/copydllsExt.py
+++ b/tools/copydllsExt.py
@@ -20,7 +20,8 @@ config.read(configFile)
 
 # check config.
 sections = ["release", "debug"]
-options  = ["cgnslib", "gdal", "geos", "hdf5", "iriclib", "netcdf", "proj", "qwt", "shapelib", "szip", "vtk", "yaml-cpp", "zlib"]
+# options  = ["cgnslib", "expat", "gdal", "geos", "hdf5", "iriclib", "netcdf", "openssl", "proj", "qwt", "shapelib", "szip", "udunits", "vtk", "yaml-cpp", "zlib"]
+options  = ["cgnslib", "gdal", "geos", "hdf5", "iriclib", "netcdf", "openssl", "proj", "qwt", "shapelib", "szip", "vtk", "yaml-cpp", "zlib"]
 for section in sections:
   if (section in config.sections()):
     for option in options:

--- a/tools/data/dirExt.prop
+++ b/tools/data/dirExt.prop
@@ -1,29 +1,35 @@
 [release]
-cgnslib  = C:/iricdev_2013/lib/install/cgnslib-3.2.1/release/bin/
+cgnslib  = C:/iricdev_2013/lib/install/cgnslib-3.2.1-patch1/release/bin/
+expat    = C:/iricdev_2013/lib/install/expat-2.2.6/release/bin/
 gdal     = C:/iricdev_2013/lib/install/gdal-1.11.2/release/bin/
 geos     = C:/iricdev_2013/lib/install/geos-3.4.3/release/bin/
 hdf5     = C:/iricdev_2013/lib/install/hdf5-1.8.14/release/bin/
-iriclib  = C:/iricdev_2013/lib/install/iriclib-26c18ba/release/lib/
+iriclib  = C:/iricdev_2013/lib/install/iriclib-3290bed/release/lib/
 netcdf   = C:/iricdev_2013/lib/install/netcdf-4.3.3/release/bin/
+openssl  = C:/iricdev_2013/lib/install/openssl-1.0.2p/release/bin/
 proj     = C:/iricdev_2013/lib/install/proj-4.8.0/release/bin/
 qwt      = C:/iricdev_2013/lib/install/Qwt-6.1.3/lib/
 shapelib = C:/iricdev_2013/lib/install/shapelib-1.3.0/release/
 szip     = C:/iricdev_2013/lib/install/hdf5-1.8.14/release/bin/
+udunits  = C:/iricdev_2013/lib/install/udunits-2.2.26/release/bin/
 vtk      = C:/iricdev_2013/lib/install/VTK-6.1.0/release/bin/
 yaml-cpp = C:/iricdev_2013/lib/install/yaml-cpp-0.5.2/release/bin
 zlib     = C:/iricdev_2013/lib/install/hdf5-1.8.14/release/bin/
 
 [debug]
-cgnslib  = C:/iricdev_2013/lib/install/cgnslib-3.2.1/debug/bin/
+cgnslib  = C:/iricdev_2013/lib/install/cgnslib-3.2.1-patch1/debug/bin/
+expat    = C:/iricdev_2013/lib/install/expat-2.2.6/debug/bin/
 gdal     = C:/iricdev_2013/lib/install/gdal-1.11.2/debug/bin/
 geos     = C:/iricdev_2013/lib/install/geos-3.4.3/debug/bin/
 hdf5     = C:/iricdev_2013/lib/install/hdf5-1.8.14/debug/bin/
-iriclib  = C:/iricdev_2013/lib/install/iriclib-26c18ba/debug/lib/
+iriclib  = C:/iricdev_2013/lib/install/iriclib-3290bed/debug/lib/
 netcdf   = C:/iricdev_2013/lib/install/netcdf-4.3.3/debug/bin/
+openssl  = C:/iricdev_2013/lib/install/openssl-1.0.2p/debug/bin/
 proj     = C:/iricdev_2013/lib/install/proj-4.8.0/release/bin/
 qwt      = C:/iricdev_2013/lib/install/Qwt-6.1.3/lib/
 shapelib = C:/iricdev_2013/lib/install/shapelib-1.3.0/debug/
 szip     = C:/iricdev_2013/lib/install/hdf5-1.8.14/debug/bin/
+udunits  = C:/iricdev_2013/lib/install/udunits-2.2.26/debug/bin/
 vtk      = C:/iricdev_2013/lib/install/VTK-6.1.0/debug/bin/
 yaml-cpp = C:/iricdev_2013/lib/install/yaml-cpp-0.5.2/debug/bin
 zlib     = C:/iricdev_2013/lib/install/hdf5-1.8.14/debug/bin/


### PR DESCRIPTION
Hi Keisuke,

Now with this appveyor integration we can test external builds by using the artifacts generated for each build configuration.  The Qt dlls aren't currently included but if you send me a list of the Qt files required to run iRIC, I will add them to the artifacts for easier testing.  Currently, I just use the "Qt 5.5 64-bit for Desktop (MSVC 2013)" shortcut to test.

Thanks,
Scott