### PR TITLE
Closes i-RIC/prepost-gui#425

### DIFF
--- a/libs/pre/datamodel/preprocessorgridattributecustommappingdialog.cpp
+++ b/libs/pre/datamodel/preprocessorgridattributecustommappingdialog.cpp
@@ -26,6 +26,7 @@ PreProcessorGridAttributeCustomMappingDialog::~PreProcessorGridAttributeCustomMa
 
 void PreProcessorGridAttributeCustomMappingDialog::setSettings(const QList<PreProcessorGridAttributeMappingSettingDataItem*>& atts, const QList<PreProcessorBCSettingDataItem*>& bcs, const PreProcessorCustomMappingSetting& setting)
 {
+	QVBoxLayout* layout = new QVBoxLayout(this);
 	if (atts.size() != 0) {
 		QGroupBox* gbox = new QGroupBox(tr("Geographic Data"), this);
 		QVBoxLayout* glayout = new QVBoxLayout(gbox);
@@ -42,7 +43,7 @@ void PreProcessorGridAttributeCustomMappingDialog::setSettings(const QList<PrePr
 		}
 		glayout->addStretch(1);
 		gbox->setLayout(glayout);
-		ui->layout->addWidget(gbox);
+		layout->addWidget(gbox);
 	}
 
 	if (bcs.size() != 0) {
@@ -61,9 +62,11 @@ void PreProcessorGridAttributeCustomMappingDialog::setSettings(const QList<PrePr
 		}
 		blayout->addStretch(1);
 		bbox->setLayout(blayout);
-		ui->layout->addWidget(bbox);
+		layout->addWidget(bbox);
 	}
-	ui->layout->addStretch(1);
+	layout->addStretch(1);
+	ui->scrollAreaWidgetContents->setLayout(layout);
+
 	adjustSize();
 }
 

--- a/libs/pre/datamodel/preprocessorgridattributecustommappingdialog.ui
+++ b/libs/pre/datamodel/preprocessorgridattributecustommappingdialog.ui
@@ -13,9 +13,23 @@
   <property name="windowTitle">
    <string>Attribute Mapping</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout" stretch="1,0">
+  <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <layout class="QVBoxLayout" name="layout"/>
+    <widget class="QScrollArea" name="scrollArea">
+     <property name="widgetResizable">
+      <bool>true</bool>
+     </property>
+     <widget class="QWidget" name="scrollAreaWidgetContents">
+      <property name="geometry">
+       <rect>
+        <x>0</x>
+        <y>0</y>
+        <width>373</width>
+        <height>241</height>
+       </rect>
+      </property>
+     </widget>
+    </widget>
    </item>
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout">


### PR DESCRIPTION
[issue_435.zip](https://github.com/i-RIC/prepost-gui/files/2523618/issue_435.zip)

To test the issue, please do the following operation:

1. Open the project file attached to this pull request.
2. Select Menu Grid -> Attribute Mapping -> Execute

Then the "Attribute Mapping" dialog will be shown.

With the current iRIC GUI, the dialog will be like this:

![issue_435_screenshot1](https://user-images.githubusercontent.com/4031569/47627130-c05e6800-db71-11e8-97da-7b70f949c23d.png)

With the issue-425 branch, the dialog will be like below:

![issue_435_screenshot2](https://user-images.githubusercontent.com/4031569/47627138-c9e7d000-db71-11e8-9c24-f596c2af4033.png)

You'll see that the dialog now has a scroll area, and it will be OK even when there are hundreds of boundary condition settings.
