### PR TITLE
Compound Channel grid generator code refactoring

### DIFF
--- a/libs/gridcreatingcondition/compoundchannel/compoundchannel.pro
+++ b/libs/gridcreatingcondition/compoundchannel/compoundchannel.pro
@@ -102,6 +102,7 @@ HEADERS += gcc_compoundchannel_global.h \
            private/gridcreatingconditioncompoundchannel_editpolygoncoordinatescommand.h \
            private/gridcreatingconditioncompoundchannel_editpolylinecoordinatescommand.h \
            private/gridcreatingconditioncompoundchannel_movepolygoncommand.h \
+           private/gridcreatingconditioncompoundchannel_movepolygonvertexcommand.h \
            private/gridcreatingconditioncompoundchannel_polygoncoordinateseditor.h \
            private/gridcreatingconditioncompoundchannel_polylinecoordinateseditor.h \
            private/gridcreatingconditioncompoundchannel_switchstatuscommand.h
@@ -120,6 +121,7 @@ SOURCES += gridcreatingconditioncompoundchannel.cpp \
            private/gridcreatingconditioncompoundchannel_editpolygoncoordinatescommand.cpp \
            private/gridcreatingconditioncompoundchannel_editpolylinecoordinatescommand.cpp \
            private/gridcreatingconditioncompoundchannel_movepolygoncommand.cpp \
+           private/gridcreatingconditioncompoundchannel_movepolygonvertexcommand.cpp \
            private/gridcreatingconditioncompoundchannel_polygoncoordinateseditor.cpp \
            private/gridcreatingconditioncompoundchannel_polylinecoordinateseditor.cpp \
            private/gridcreatingconditioncompoundchannel_switchstatuscommand.cpp

--- a/libs/gridcreatingcondition/compoundchannel/compoundchannel.pro
+++ b/libs/gridcreatingcondition/compoundchannel/compoundchannel.pro
@@ -100,6 +100,7 @@ HEADERS += gcc_compoundchannel_global.h \
            gridcreatingconditioncreatorcompoundchannel.h \
            private/gridcreatingconditioncompoundchannel_addpolygonvertexcommand.h \
            private/gridcreatingconditioncompoundchannel_definepolygonnewpointcommand.h \
+           private/gridcreatingconditioncompoundchannel_definepolylinenewpointcommand.h \
            private/gridcreatingconditioncompoundchannel_editpolygoncoordinatescommand.h \
            private/gridcreatingconditioncompoundchannel_editpolylinecoordinatescommand.h \
            private/gridcreatingconditioncompoundchannel_movepolygoncommand.h \
@@ -120,6 +121,7 @@ SOURCES += gridcreatingconditioncompoundchannel.cpp \
            gridcreatingconditioncreatorcompoundchannel.cpp \
            private/gridcreatingconditioncompoundchannel_addpolygonvertexcommand.cpp \
            private/gridcreatingconditioncompoundchannel_definepolygonnewpointcommand.cpp \
+           private/gridcreatingconditioncompoundchannel_definepolylinenewpointcommand.cpp \
            private/gridcreatingconditioncompoundchannel_editpolygoncoordinatescommand.cpp \
            private/gridcreatingconditioncompoundchannel_editpolylinecoordinatescommand.cpp \
            private/gridcreatingconditioncompoundchannel_movepolygoncommand.cpp \

--- a/libs/gridcreatingcondition/compoundchannel/compoundchannel.pro
+++ b/libs/gridcreatingcondition/compoundchannel/compoundchannel.pro
@@ -105,6 +105,7 @@ HEADERS += gcc_compoundchannel_global.h \
            private/gridcreatingconditioncompoundchannel_editpolylinecoordinatescommand.h \
            private/gridcreatingconditioncompoundchannel_movepolygoncommand.h \
            private/gridcreatingconditioncompoundchannel_movepolygonvertexcommand.h \
+           private/gridcreatingconditioncompoundchannel_movepolylinecommand.h \
            private/gridcreatingconditioncompoundchannel_polygoncoordinateseditor.h \
            private/gridcreatingconditioncompoundchannel_polylinecoordinateseditor.h \
            private/gridcreatingconditioncompoundchannel_switchstatuscommand.h
@@ -126,6 +127,7 @@ SOURCES += gridcreatingconditioncompoundchannel.cpp \
            private/gridcreatingconditioncompoundchannel_editpolylinecoordinatescommand.cpp \
            private/gridcreatingconditioncompoundchannel_movepolygoncommand.cpp \
            private/gridcreatingconditioncompoundchannel_movepolygonvertexcommand.cpp \
+           private/gridcreatingconditioncompoundchannel_movepolylinecommand.cpp \
            private/gridcreatingconditioncompoundchannel_polygoncoordinateseditor.cpp \
            private/gridcreatingconditioncompoundchannel_polylinecoordinateseditor.cpp \
            private/gridcreatingconditioncompoundchannel_switchstatuscommand.cpp

--- a/libs/gridcreatingcondition/compoundchannel/compoundchannel.pro
+++ b/libs/gridcreatingcondition/compoundchannel/compoundchannel.pro
@@ -110,6 +110,7 @@ HEADERS += gcc_compoundchannel_global.h \
            private/gridcreatingconditioncompoundchannel_movepolylinevertexcommand.h \
            private/gridcreatingconditioncompoundchannel_polygoncoordinateseditor.h \
            private/gridcreatingconditioncompoundchannel_polylinecoordinateseditor.h \
+           private/gridcreatingconditioncompoundchannel_removepolygonvertexcommand.h \
            private/gridcreatingconditioncompoundchannel_switchstatuscommand.h
 FORMS += gridcreatingconditioncompoundchannelsettingdialog.ui
 SOURCES += gridcreatingconditioncompoundchannel.cpp \
@@ -134,6 +135,7 @@ SOURCES += gridcreatingconditioncompoundchannel.cpp \
            private/gridcreatingconditioncompoundchannel_movepolylinevertexcommand.cpp \
            private/gridcreatingconditioncompoundchannel_polygoncoordinateseditor.cpp \
            private/gridcreatingconditioncompoundchannel_polylinecoordinateseditor.cpp \
+           private/gridcreatingconditioncompoundchannel_removepolygonvertexcommand.cpp \
            private/gridcreatingconditioncompoundchannel_switchstatuscommand.cpp
 RESOURCES += compoundchannel.qrc
 TRANSLATIONS += languages/iricGccCompoundchannel_es_ES.ts \

--- a/libs/gridcreatingcondition/compoundchannel/compoundchannel.pro
+++ b/libs/gridcreatingcondition/compoundchannel/compoundchannel.pro
@@ -98,6 +98,7 @@ HEADERS += gcc_compoundchannel_global.h \
            gridcreatingconditioncompoundchannelsettingdialog.h \
            gridcreatingconditioncompoundchannelspline.h \
            gridcreatingconditioncreatorcompoundchannel.h \
+           private/gridcreatingconditioncompoundchannel_addpolygonvertexcommand.h \
            private/gridcreatingconditioncompoundchannel_definepolygonnewpointcommand.h \
            private/gridcreatingconditioncompoundchannel_editpolygoncoordinatescommand.h \
            private/gridcreatingconditioncompoundchannel_editpolylinecoordinatescommand.h \
@@ -117,6 +118,7 @@ SOURCES += gridcreatingconditioncompoundchannel.cpp \
            gridcreatingconditioncompoundchannelsettingdialog.cpp \
            gridcreatingconditioncompoundchannelspline.cpp \
            gridcreatingconditioncreatorcompoundchannel.cpp \
+           private/gridcreatingconditioncompoundchannel_addpolygonvertexcommand.cpp \
            private/gridcreatingconditioncompoundchannel_definepolygonnewpointcommand.cpp \
            private/gridcreatingconditioncompoundchannel_editpolygoncoordinatescommand.cpp \
            private/gridcreatingconditioncompoundchannel_editpolylinecoordinatescommand.cpp \

--- a/libs/gridcreatingcondition/compoundchannel/compoundchannel.pro
+++ b/libs/gridcreatingcondition/compoundchannel/compoundchannel.pro
@@ -101,9 +101,9 @@ HEADERS += gcc_compoundchannel_global.h \
            private/gridcreatingconditioncompoundchannel_editpolygoncoordinatescommand.h \
            private/gridcreatingconditioncompoundchannel_editpolylinecoordinatescommand.h \
            private/gridcreatingconditioncompoundchannel_polygoncoordinateseditor.h \
-           private/gridcreatingconditioncompoundchannel_polylinecoordinateseditor.h
-FORMS += \
-         gridcreatingconditioncompoundchannelsettingdialog.ui
+           private/gridcreatingconditioncompoundchannel_polylinecoordinateseditor.h \
+           private/gridcreatingconditioncompoundchannel_switchstatuscommand.h
+FORMS += gridcreatingconditioncompoundchannelsettingdialog.ui
 SOURCES += gridcreatingconditioncompoundchannel.cpp \
            gridcreatingconditioncompoundchannelabstractline.cpp \
            gridcreatingconditioncompoundchannelabstractpolygon.cpp \
@@ -117,7 +117,8 @@ SOURCES += gridcreatingconditioncompoundchannel.cpp \
            private/gridcreatingconditioncompoundchannel_editpolygoncoordinatescommand.cpp \
            private/gridcreatingconditioncompoundchannel_editpolylinecoordinatescommand.cpp \
            private/gridcreatingconditioncompoundchannel_polygoncoordinateseditor.cpp \
-           private/gridcreatingconditioncompoundchannel_polylinecoordinateseditor.cpp
+           private/gridcreatingconditioncompoundchannel_polylinecoordinateseditor.cpp \
+           private/gridcreatingconditioncompoundchannel_switchstatuscommand.cpp
 RESOURCES += compoundchannel.qrc
 TRANSLATIONS += languages/iricGccCompoundchannel_es_ES.ts \
                 languages/iricGccCompoundchannel_fr_FR.ts \

--- a/libs/gridcreatingcondition/compoundchannel/compoundchannel.pro
+++ b/libs/gridcreatingcondition/compoundchannel/compoundchannel.pro
@@ -106,6 +106,7 @@ HEADERS += gcc_compoundchannel_global.h \
            private/gridcreatingconditioncompoundchannel_movepolygoncommand.h \
            private/gridcreatingconditioncompoundchannel_movepolygonvertexcommand.h \
            private/gridcreatingconditioncompoundchannel_movepolylinecommand.h \
+           private/gridcreatingconditioncompoundchannel_movepolylinevertexcommand.h \
            private/gridcreatingconditioncompoundchannel_polygoncoordinateseditor.h \
            private/gridcreatingconditioncompoundchannel_polylinecoordinateseditor.h \
            private/gridcreatingconditioncompoundchannel_switchstatuscommand.h
@@ -128,6 +129,7 @@ SOURCES += gridcreatingconditioncompoundchannel.cpp \
            private/gridcreatingconditioncompoundchannel_movepolygoncommand.cpp \
            private/gridcreatingconditioncompoundchannel_movepolygonvertexcommand.cpp \
            private/gridcreatingconditioncompoundchannel_movepolylinecommand.cpp \
+           private/gridcreatingconditioncompoundchannel_movepolylinevertexcommand.cpp \
            private/gridcreatingconditioncompoundchannel_polygoncoordinateseditor.cpp \
            private/gridcreatingconditioncompoundchannel_polylinecoordinateseditor.cpp \
            private/gridcreatingconditioncompoundchannel_switchstatuscommand.cpp

--- a/libs/gridcreatingcondition/compoundchannel/compoundchannel.pro
+++ b/libs/gridcreatingcondition/compoundchannel/compoundchannel.pro
@@ -98,6 +98,7 @@ HEADERS += gcc_compoundchannel_global.h \
            gridcreatingconditioncompoundchannelsettingdialog.h \
            gridcreatingconditioncompoundchannelspline.h \
            gridcreatingconditioncreatorcompoundchannel.h \
+           private/gridcreatingconditioncompoundchannel_definepolygonnewpointcommand.h \
            private/gridcreatingconditioncompoundchannel_editpolygoncoordinatescommand.h \
            private/gridcreatingconditioncompoundchannel_editpolylinecoordinatescommand.h \
            private/gridcreatingconditioncompoundchannel_polygoncoordinateseditor.h \
@@ -114,6 +115,7 @@ SOURCES += gridcreatingconditioncompoundchannel.cpp \
            gridcreatingconditioncompoundchannelsettingdialog.cpp \
            gridcreatingconditioncompoundchannelspline.cpp \
            gridcreatingconditioncreatorcompoundchannel.cpp \
+           private/gridcreatingconditioncompoundchannel_definepolygonnewpointcommand.cpp \
            private/gridcreatingconditioncompoundchannel_editpolygoncoordinatescommand.cpp \
            private/gridcreatingconditioncompoundchannel_editpolylinecoordinatescommand.cpp \
            private/gridcreatingconditioncompoundchannel_polygoncoordinateseditor.cpp \

--- a/libs/gridcreatingcondition/compoundchannel/compoundchannel.pro
+++ b/libs/gridcreatingcondition/compoundchannel/compoundchannel.pro
@@ -99,6 +99,7 @@ HEADERS += gcc_compoundchannel_global.h \
            gridcreatingconditioncompoundchannelspline.h \
            gridcreatingconditioncreatorcompoundchannel.h \
            private/gridcreatingconditioncompoundchannel_addpolygonvertexcommand.h \
+           private/gridcreatingconditioncompoundchannel_addpolylinevertexcommand.h \
            private/gridcreatingconditioncompoundchannel_definepolygonnewpointcommand.h \
            private/gridcreatingconditioncompoundchannel_definepolylinenewpointcommand.h \
            private/gridcreatingconditioncompoundchannel_editpolygoncoordinatescommand.h \
@@ -122,6 +123,7 @@ SOURCES += gridcreatingconditioncompoundchannel.cpp \
            gridcreatingconditioncompoundchannelspline.cpp \
            gridcreatingconditioncreatorcompoundchannel.cpp \
            private/gridcreatingconditioncompoundchannel_addpolygonvertexcommand.cpp \
+           private/gridcreatingconditioncompoundchannel_addpolylinevertexcommand.cpp \
            private/gridcreatingconditioncompoundchannel_definepolygonnewpointcommand.cpp \
            private/gridcreatingconditioncompoundchannel_definepolylinenewpointcommand.cpp \
            private/gridcreatingconditioncompoundchannel_editpolygoncoordinatescommand.cpp \

--- a/libs/gridcreatingcondition/compoundchannel/compoundchannel.pro
+++ b/libs/gridcreatingcondition/compoundchannel/compoundchannel.pro
@@ -111,6 +111,7 @@ HEADERS += gcc_compoundchannel_global.h \
            private/gridcreatingconditioncompoundchannel_polygoncoordinateseditor.h \
            private/gridcreatingconditioncompoundchannel_polylinecoordinateseditor.h \
            private/gridcreatingconditioncompoundchannel_removepolygonvertexcommand.h \
+           private/gridcreatingconditioncompoundchannel_removepolylinevertexcommand.h \
            private/gridcreatingconditioncompoundchannel_switchstatuscommand.h
 FORMS += gridcreatingconditioncompoundchannelsettingdialog.ui
 SOURCES += gridcreatingconditioncompoundchannel.cpp \
@@ -136,6 +137,7 @@ SOURCES += gridcreatingconditioncompoundchannel.cpp \
            private/gridcreatingconditioncompoundchannel_polygoncoordinateseditor.cpp \
            private/gridcreatingconditioncompoundchannel_polylinecoordinateseditor.cpp \
            private/gridcreatingconditioncompoundchannel_removepolygonvertexcommand.cpp \
+           private/gridcreatingconditioncompoundchannel_removepolylinevertexcommand.cpp \
            private/gridcreatingconditioncompoundchannel_switchstatuscommand.cpp
 RESOURCES += compoundchannel.qrc
 TRANSLATIONS += languages/iricGccCompoundchannel_es_ES.ts \

--- a/libs/gridcreatingcondition/compoundchannel/compoundchannel.pro
+++ b/libs/gridcreatingcondition/compoundchannel/compoundchannel.pro
@@ -101,6 +101,7 @@ HEADERS += gcc_compoundchannel_global.h \
            private/gridcreatingconditioncompoundchannel_definepolygonnewpointcommand.h \
            private/gridcreatingconditioncompoundchannel_editpolygoncoordinatescommand.h \
            private/gridcreatingconditioncompoundchannel_editpolylinecoordinatescommand.h \
+           private/gridcreatingconditioncompoundchannel_movepolygoncommand.h \
            private/gridcreatingconditioncompoundchannel_polygoncoordinateseditor.h \
            private/gridcreatingconditioncompoundchannel_polylinecoordinateseditor.h \
            private/gridcreatingconditioncompoundchannel_switchstatuscommand.h
@@ -118,6 +119,7 @@ SOURCES += gridcreatingconditioncompoundchannel.cpp \
            private/gridcreatingconditioncompoundchannel_definepolygonnewpointcommand.cpp \
            private/gridcreatingconditioncompoundchannel_editpolygoncoordinatescommand.cpp \
            private/gridcreatingconditioncompoundchannel_editpolylinecoordinatescommand.cpp \
+           private/gridcreatingconditioncompoundchannel_movepolygoncommand.cpp \
            private/gridcreatingconditioncompoundchannel_polygoncoordinateseditor.cpp \
            private/gridcreatingconditioncompoundchannel_polylinecoordinateseditor.cpp \
            private/gridcreatingconditioncompoundchannel_switchstatuscommand.cpp

--- a/libs/gridcreatingcondition/compoundchannel/gridcreatingconditioncompoundchannel.cpp
+++ b/libs/gridcreatingcondition/compoundchannel/gridcreatingconditioncompoundchannel.cpp
@@ -19,6 +19,7 @@
 #include "private/gridcreatingconditioncompoundchannel_polygoncoordinateseditor.h"
 #include "private/gridcreatingconditioncompoundchannel_polylinecoordinateseditor.h"
 #include "private/gridcreatingconditioncompoundchannel_removepolygonvertexcommand.h"
+#include "private/gridcreatingconditioncompoundchannel_removepolylinevertexcommand.h"
 #include "private/gridcreatingconditioncompoundchannel_switchstatuscommand.h"
 
 #include <guibase/widget/waitdialog.h>
@@ -315,75 +316,6 @@ void GridCreatingConditionCompoundChannel::mouseMoveEvent(QMouseEvent* event, Pr
 	}
 }
 
-class GridCreatingConditionCompoundChannel::RemovePolyLineVertexCommand : public QUndoCommand
-{
-public:
-	RemovePolyLineVertexCommand(vtkIdType vertexId, GridCreatingConditionCompoundChannel* pol) :
-		QUndoCommand {GridCreatingConditionCompoundChannel::tr("Remove Polygonal Line Vertex")}
-	{
-		m_vertexId = vertexId;
-		double p[3];
-		pol->m_selectedLine->getVtkLine()->GetPoints()->GetPoint(m_vertexId, p);
-		m_vertexPosition = QVector2D(p[0], p[1]);
-		m_polygon = pol;
-		m_targetLine = m_polygon->m_selectedLine;
-	}
-	void redo() {
-		vtkPoints* points = m_targetLine->getVtkLine()->GetPoints();
-		QVector<QVector2D> positions;
-		positions.reserve(points->GetNumberOfPoints());
-		double p[3];
-		for (vtkIdType i = 0; i < m_vertexId; ++i) {
-			points->GetPoint(i, p);
-			positions.append(QVector2D(p[0], p[1]));
-		}
-		// skip vertex in m_vertexId[
-		for (vtkIdType i = m_vertexId + 1; i < points->GetNumberOfPoints(); ++i) {
-			points->GetPoint(i, p);
-			positions.append(QVector2D(p[0], p[1]));
-		}
-		points->SetNumberOfPoints(positions.count());
-		for (vtkIdType i = 0; i < positions.count(); ++i) {
-			QVector2D v = positions.at(i);
-			points->SetPoint(i, v.x(), v.y(), 0);
-		}
-		points->Modified();
-		m_polygon->m_mouseEventMode = GridCreatingConditionCompoundChannel::meNormal;
-		m_targetLine->getVtkLine()->Modified();
-		m_targetLine->updateShapeData();
-		m_polygon->renderGraphicsView();
-	}
-	void undo() {
-		vtkPoints* points = m_targetLine->getVtkLine()->GetPoints();
-		QVector<QVector2D> positions;
-		positions.reserve(points->GetNumberOfPoints());
-		double p[3];
-		for (vtkIdType i = 0; i < m_vertexId; ++i) {
-			points->GetPoint(i, p);
-			positions.append(QVector2D(p[0], p[1]));
-		}
-		positions.append(m_vertexPosition);
-		for (vtkIdType i = m_vertexId; i < points->GetNumberOfPoints(); ++i) {
-			points->GetPoint(i, p);
-			positions.append(QVector2D(p[0], p[1]));
-		}
-		points->SetNumberOfPoints(positions.count());
-		for (vtkIdType i = 0; i < positions.count(); ++i) {
-			QVector2D v = positions.at(i);
-			points->SetPoint(i, v.x(), v.y(), 0);
-		}
-		points->Modified();
-		m_targetLine->getVtkLine()->Modified();
-		m_targetLine->updateShapeData();
-		m_polygon->renderGraphicsView();
-	}
-private:
-	vtkIdType m_vertexId;
-	QVector2D m_vertexPosition;
-	GridCreatingConditionCompoundChannel* m_polygon;
-	GridCreatingConditionCompoundChannelAbstractLine* m_targetLine;
-};
-
 void GridCreatingConditionCompoundChannel::mousePressEvent(QMouseEvent* event, PreProcessorGraphicsViewInterface* v)
 {
 	if (event->button() == Qt::LeftButton) {
@@ -543,7 +475,7 @@ void GridCreatingConditionCompoundChannel::mousePressEvent(QMouseEvent* event, P
 					if (m_selectedLine->polyLine().count() == 1) {
 						// ignore.
 					} else {
-						iRICUndoStack::instance().push(new RemovePolyLineVertexCommand(m_selectedLine->selectedVertexId(), this));
+						pushRenderCommand(new RemovePolyLineVertexCommand(m_selectedLine->selectedVertexId(), this));
 					}
 					m_inhibitSelect = true;
 					break;

--- a/libs/gridcreatingcondition/compoundchannel/gridcreatingconditioncompoundchannel.cpp
+++ b/libs/gridcreatingcondition/compoundchannel/gridcreatingconditioncompoundchannel.cpp
@@ -9,6 +9,7 @@
 #include "gridcreatingconditioncompoundchannelspline.h"
 
 #include "private/gridcreatingconditioncompoundchannel_definepolygonnewpointcommand.h"
+#include "private/gridcreatingconditioncompoundchannel_movepolygoncommand.h"
 #include "private/gridcreatingconditioncompoundchannel_polygoncoordinateseditor.h"
 #include "private/gridcreatingconditioncompoundchannel_polylinecoordinateseditor.h"
 #include "private/gridcreatingconditioncompoundchannel_switchstatuscommand.h"
@@ -212,74 +213,6 @@ void GridCreatingConditionCompoundChannel::mouseDoubleClickEvent(QMouseEvent* /*
 		defineLine(true);
 	}
 }
-
-class GridCreatingConditionCompoundChannel::MovePolygonCommand : public QUndoCommand
-{
-public:
-	MovePolygonCommand(bool keyDown, const QPoint& from, const QPoint& to, GridCreatingConditionCompoundChannel* pol) :
-		QUndoCommand {GridCreatingConditionCompoundChannel::tr("Move Polygon")}
-	{
-		m_keyDown = keyDown;
-		double dx = from.x();
-		double dy = from.y();
-		pol->graphicsView()->viewportToWorld(dx, dy);
-		QVector2D fromVec(dx, dy);
-		dx = to.x();
-		dy = to.y();
-		pol->graphicsView()->viewportToWorld(dx, dy);
-		QVector2D toVec(dx, dy);
-		m_offset = toVec - fromVec;
-		m_polygon = pol;
-		m_targetPolygon = m_polygon->m_selectedPolygon;
-	}
-	void redo() {
-		vtkPolygon* pol = m_targetPolygon->getVtkPolygon();
-		vtkPoints* points = pol->GetPoints();
-		for (vtkIdType i = 0; i < points->GetNumberOfPoints(); ++i) {
-			double p[3];
-			points->GetPoint(i, p);
-			p[0] += m_offset.x();
-			p[1] += m_offset.y();
-			points->SetPoint(i, p);
-		}
-		points->Modified();
-		pol->Modified();
-		m_targetPolygon->updateShapeData();
-		m_polygon->renderGraphicsView();
-	}
-	void undo() {
-		vtkPolygon* pol = m_targetPolygon->getVtkPolygon();
-		vtkPoints* points = pol->GetPoints();
-		for (vtkIdType i = 0; i < points->GetNumberOfPoints(); ++i) {
-			double p[3];
-			points->GetPoint(i, p);
-			p[0] -= m_offset.x();
-			p[1] -= m_offset.y();
-			points->SetPoint(i, p);
-		}
-		points->Modified();
-		pol->Modified();
-		m_targetPolygon->updateShapeData();
-		m_polygon->renderGraphicsView();
-	}
-	int id() const {
-		return iRIC::generateCommandId("GridCreatingConditionCompoundChannelMovePolygonCommand");
-	}
-	bool mergeWith(const QUndoCommand* other) {
-		const MovePolygonCommand* comm = dynamic_cast<const MovePolygonCommand*>(other);
-		if (comm == nullptr) {return false;}
-		if (comm->m_keyDown) {return false;}
-		if (comm->m_polygon != m_polygon) {return false;}
-		if (comm->m_targetPolygon != m_targetPolygon) {return false;}
-		m_offset += comm->m_offset;
-		return true;
-	}
-private:
-	bool m_keyDown;
-	GridCreatingConditionCompoundChannel* m_polygon;
-	GridCreatingConditionCompoundChannelAbstractPolygon* m_targetPolygon;
-	QVector2D m_offset;
-};
 
 class GridCreatingConditionCompoundChannel::MovePolygonVertexCommand : public QUndoCommand
 {
@@ -787,7 +720,7 @@ void GridCreatingConditionCompoundChannel::mouseMoveEvent(QMouseEvent* event, Pr
 				break;
 			case meTranslate:
 				// execute translation.
-				iRICUndoStack::instance().push(new MovePolygonCommand(false, m_currentPoint, QPoint(event->x(), event->y()), this));
+				pushRenderCommand(new MovePolygonCommand(false, m_currentPoint, QPoint(event->x(), event->y()), this));
 				m_currentPoint = QPoint(event->x(), event->y());
 				break;
 			case meMoveVertex:
@@ -1049,7 +982,7 @@ void GridCreatingConditionCompoundChannel::mousePressEvent(QMouseEvent* event, P
 						m_mouseEventMode = meTranslate;
 						m_currentPoint = QPoint(event->x(), event->y());
 						// push the first translation command.
-						iRICUndoStack::instance().push(new MovePolygonCommand(true, m_currentPoint, m_currentPoint, this));
+						pushRenderCommand(new MovePolygonCommand(true, m_currentPoint, m_currentPoint, this));
 					}
 					break;
 				case meMoveVertexPrepare:

--- a/libs/gridcreatingcondition/compoundchannel/gridcreatingconditioncompoundchannel.cpp
+++ b/libs/gridcreatingcondition/compoundchannel/gridcreatingconditioncompoundchannel.cpp
@@ -526,13 +526,13 @@ void GridCreatingConditionCompoundChannel::mouseMoveEvent(QMouseEvent* event, Pr
 		// defining a polygon
 		// update the position of the last point.
 		if (m_mouseEventMode == meDefining) {
-			pushRenderCommand(new DefinePolygonNewPointCommand(false, QPoint(event->x(), event->y()), this));
+			pushRenderCommand(new DefinePolygonNewPointCommand(false, event->pos(), this));
 		}
 	} else if (m_status == stDefiningCenterLine) {
 		// defining a polyline.
 		// update the position of the last point.
 		if (m_mouseEventMode == meDefining) {
-			iRICUndoStack::instance().push(new DefinePolyLineNewPointCommand(false, QPoint(event->x(), event->y()), this));
+			iRICUndoStack::instance().push(new DefinePolyLineNewPointCommand(false, event->pos(), this));
 		}
 	} else if (m_status == stNormal) {
 		// defining stage finished.
@@ -546,7 +546,7 @@ void GridCreatingConditionCompoundChannel::mouseMoveEvent(QMouseEvent* event, Pr
 			case meAddVertexNotPossible:
 			case meRemoveVertexPrepare:
 			case meRemoveVertexNotPossible:
-				m_currentPoint = QPoint(event->x(), event->y());
+				m_currentPoint = event->pos();
 				updateMouseEventMode();
 				updateMouseCursor(v);
 				break;
@@ -557,15 +557,15 @@ void GridCreatingConditionCompoundChannel::mouseMoveEvent(QMouseEvent* event, Pr
 				break;
 			case meTranslate:
 				// execute translation.
-				pushRenderCommand(new MovePolygonCommand(false, m_currentPoint, QPoint(event->x(), event->y()), this));
-				m_currentPoint = QPoint(event->x(), event->y());
+				pushRenderCommand(new MovePolygonCommand(false, m_currentPoint, event->pos(), this));
+				m_currentPoint = event->pos();
 				break;
 			case meMoveVertex:
-				pushRenderCommand(new MovePolygonVertexCommand(false, m_currentPoint, QPoint(event->x(), event->y()), m_selectedPolygon->selectedVertexId(), this));
-				m_currentPoint = QPoint(event->x(), event->y());
+				pushRenderCommand(new MovePolygonVertexCommand(false, m_currentPoint, event->pos(), m_selectedPolygon->selectedVertexId(), this));
+				m_currentPoint = event->pos();
 				break;
 			case meAddVertex:
-				pushRenderCommand(new AddPolygonVertexCommand(false, m_selectedPolygon->selectedEdgeId(), QPoint(event->x(), event->y()), this));
+				pushRenderCommand(new AddPolygonVertexCommand(false, m_selectedPolygon->selectedEdgeId(), event->pos(), this));
 				break;
 			case meTranslateDialog:
 				break;
@@ -582,7 +582,7 @@ void GridCreatingConditionCompoundChannel::mouseMoveEvent(QMouseEvent* event, Pr
 			case meAddVertexNotPossible:
 			case meRemoveVertexPrepare:
 			case meRemoveVertexNotPossible:
-				m_currentPoint = QPoint(event->x(), event->y());
+				m_currentPoint = event->pos();
 				updateMouseEventMode();
 				updateMouseCursor(v);
 				break;
@@ -593,15 +593,15 @@ void GridCreatingConditionCompoundChannel::mouseMoveEvent(QMouseEvent* event, Pr
 				break;
 			case meTranslate:
 				// execute translation.
-				iRICUndoStack::instance().push(new MovePolyLineCommand(false, m_currentPoint, QPoint(event->x(), event->y()), this));
-				m_currentPoint = QPoint(event->x(), event->y());
+				iRICUndoStack::instance().push(new MovePolyLineCommand(false, m_currentPoint, event->pos(), this));
+				m_currentPoint = event->pos();
 				break;
 			case meMoveVertex:
-				iRICUndoStack::instance().push(new MovePolyLineVertexCommand(false, m_currentPoint, QPoint(event->x(), event->y()), m_selectedLine->selectedVertexId(), this));
-				m_currentPoint = QPoint(event->x(), event->y());
+				iRICUndoStack::instance().push(new MovePolyLineVertexCommand(false, m_currentPoint, event->pos(), m_selectedLine->selectedVertexId(), this));
+				m_currentPoint = event->pos();
 				break;
 			case meAddVertex:
-				iRICUndoStack::instance().push(new AddPolyLineVertexCommand(false, m_selectedLine->selectedEdgeId(), QPoint(event->x(), event->y()), this));
+				iRICUndoStack::instance().push(new AddPolyLineVertexCommand(false, m_selectedLine->selectedEdgeId(), event->pos(), this));
 				break;
 			case meTranslateDialog:
 				break;
@@ -817,20 +817,20 @@ void GridCreatingConditionCompoundChannel::mousePressEvent(QMouseEvent* event, P
 					} else {
 						// start translating
 						m_mouseEventMode = meTranslate;
-						m_currentPoint = QPoint(event->x(), event->y());
+						m_currentPoint = event->pos();
 						// push the first translation command.
 						pushRenderCommand(new MovePolygonCommand(true, m_currentPoint, m_currentPoint, this));
 					}
 					break;
 				case meMoveVertexPrepare:
 					m_mouseEventMode = meMoveVertex;
-					m_currentPoint = QPoint(event->x(), event->y());
+					m_currentPoint = event->pos();
 					// push the first move command.
 					pushRenderCommand(new MovePolygonVertexCommand(true, m_currentPoint, m_currentPoint, m_selectedPolygon->selectedVertexId(), this));
 					break;
 				case meAddVertexPrepare:
 					m_mouseEventMode = meAddVertex;
-					pushRenderCommand(new AddPolygonVertexCommand(true, m_selectedPolygon->selectedEdgeId(), QPoint(event->x(), event->y()), this));
+					pushRenderCommand(new AddPolygonVertexCommand(true, m_selectedPolygon->selectedEdgeId(), event->pos(), this));
 					break;
 				case meAddVertexNotPossible:
 					// do nothing.
@@ -889,20 +889,20 @@ void GridCreatingConditionCompoundChannel::mousePressEvent(QMouseEvent* event, P
 					} else {
 						// start translating
 						m_mouseEventMode = meTranslate;
-						m_currentPoint = QPoint(event->x(), event->y());
+						m_currentPoint = event->pos();
 						// push the first translation command.
 						iRICUndoStack::instance().push(new MovePolyLineCommand(true, m_currentPoint, m_currentPoint, this));
 					}
 					break;
 				case meMoveVertexPrepare:
 					m_mouseEventMode = meMoveVertex;
-					m_currentPoint = QPoint(event->x(), event->y());
+					m_currentPoint = event->pos();
 					// push the first move command.
 					iRICUndoStack::instance().push(new MovePolyLineVertexCommand(true, m_currentPoint, m_currentPoint, m_selectedLine->selectedVertexId(), this));
 					break;
 				case meAddVertexPrepare:
 					m_mouseEventMode = meAddVertex;
-					iRICUndoStack::instance().push(new AddPolyLineVertexCommand(true, m_selectedLine->selectedEdgeId(), QPoint(event->x(), event->y()), this));
+					iRICUndoStack::instance().push(new AddPolyLineVertexCommand(true, m_selectedLine->selectedEdgeId(), event->pos(), this));
 					break;
 				case meAddVertexNotPossible:
 					// do nothing.
@@ -949,7 +949,7 @@ void GridCreatingConditionCompoundChannel::mousePressEvent(QMouseEvent* event, P
 		}
 	} else if (event->button() == Qt::RightButton) {
 		// right click
-		m_dragStartPoint = QPoint(event->x(), event->y());
+		m_dragStartPoint = event->pos();
 	}
 }
 
@@ -967,7 +967,7 @@ void GridCreatingConditionCompoundChannel::mouseReleaseEvent(QMouseEvent* event,
 		case meTranslate:
 		case meMoveVertex:
 		case meAddVertex:
-			m_currentPoint = QPoint(event->x(), event->y());
+			m_currentPoint = event->pos();
 			updateMouseEventMode();
 			updateMouseCursor(v);
 			updateActionStatus();

--- a/libs/gridcreatingcondition/compoundchannel/gridcreatingconditioncompoundchannel.cpp
+++ b/libs/gridcreatingcondition/compoundchannel/gridcreatingconditioncompoundchannel.cpp
@@ -634,6 +634,11 @@ void GridCreatingConditionCompoundChannel::defineLine(bool doubleClick)
 	stack.endMacro();
 }
 
+const QColor& GridCreatingConditionCompoundChannel::color() const
+{
+	return m_color;
+}
+
 void GridCreatingConditionCompoundChannel::addVertexMode(bool on)
 {
 	if (on) {
@@ -740,6 +745,11 @@ void GridCreatingConditionCompoundChannel::saveExternalData(const QString& filen
 	s << m_lowWaterChannelPolygon->polygon(QPointF(-off.x(), -off.y()));
 	s << m_centerLine->polyLine(QPointF(-off.x(), -off.y()));
 	f.close();
+}
+
+void GridCreatingConditionCompoundChannel::updateFilename()
+{
+	setFilename("gridcreatingcondition.dat");
 }
 
 void GridCreatingConditionCompoundChannel::updateZDepthRangeItemCount(ZDepthRange& range)
@@ -923,6 +933,11 @@ void GridCreatingConditionCompoundChannel::restoreMouseEventMode()
 	m_mouseEventMode = meNormal;
 }
 
+void GridCreatingConditionCompoundChannel::cancel()
+{
+	m_canceled = true;
+}
+
 bool GridCreatingConditionCompoundChannel::create(QWidget* parent)
 {
 	if (! checkCondition()) {return false;}
@@ -974,6 +989,11 @@ void GridCreatingConditionCompoundChannel::clear()
 
 	updateMouseCursor(graphicsView());
 	updateActionStatus();
+}
+
+bool GridCreatingConditionCompoundChannel::ready() const
+{
+	return true;
 }
 
 void GridCreatingConditionCompoundChannel::showInitialDialog()

--- a/libs/gridcreatingcondition/compoundchannel/gridcreatingconditioncompoundchannel.cpp
+++ b/libs/gridcreatingcondition/compoundchannel/gridcreatingconditioncompoundchannel.cpp
@@ -8,6 +8,7 @@
 #include "gridcreatingconditioncompoundchannelsettingdialog.h"
 #include "gridcreatingconditioncompoundchannelspline.h"
 
+#include "private/gridcreatingconditioncompoundchannel_addpolygonvertexcommand.h"
 #include "private/gridcreatingconditioncompoundchannel_definepolygonnewpointcommand.h"
 #include "private/gridcreatingconditioncompoundchannel_movepolygoncommand.h"
 #include "private/gridcreatingconditioncompoundchannel_movepolygonvertexcommand.h"
@@ -214,102 +215,6 @@ void GridCreatingConditionCompoundChannel::mouseDoubleClickEvent(QMouseEvent* /*
 		defineLine(true);
 	}
 }
-
-class GridCreatingConditionCompoundChannel::AddPolygonVertexCommand : public QUndoCommand
-{
-public:
-	AddPolygonVertexCommand(bool keyDown, vtkIdType edgeId, QPoint point, GridCreatingConditionCompoundChannel* pol) :
-		QUndoCommand {GridCreatingConditionCompoundChannel::tr("Insert Polygon Vertex")}
-	{
-		m_keyDown = keyDown;
-		m_vertexId = (edgeId + 1) % (pol->m_selectedPolygon->getVtkPolygon()->GetNumberOfPoints() + 1);
-		double dx = point.x();
-		double dy = point.y();
-		pol->graphicsView()->viewportToWorld(dx, dy);
-		m_vertexPosition = QVector2D(dx, dy);
-		m_polygon = pol;
-		m_targetPolygon = m_polygon->m_selectedPolygon;
-	}
-	void redo() {
-		if (m_keyDown) {
-			// add vertex.
-			vtkPoints* points = m_targetPolygon->getVtkPolygon()->GetPoints();
-			QVector<QVector2D> positions;
-			positions.reserve(points->GetNumberOfPoints());
-			double p[3];
-			for (vtkIdType i = 0; i < m_vertexId; ++i) {
-				points->GetPoint(i, p);
-				positions.append(QVector2D(p[0], p[1]));
-			}
-			positions.append(m_vertexPosition);
-			for (vtkIdType i = m_vertexId; i < points->GetNumberOfPoints(); ++i) {
-				points->GetPoint(i, p);
-				positions.append(QVector2D(p[0], p[1]));
-			}
-			points->SetNumberOfPoints(positions.count());
-			for (vtkIdType i = 0; i < positions.count(); ++i) {
-				QVector2D v = positions.at(i);
-				points->SetPoint(i, v.x(), v.y(), 0);
-			}
-			points->Modified();
-		} else {
-			// just modify the vertex position
-			vtkPoints* points = m_targetPolygon->getVtkPolygon()->GetPoints();
-			points->SetPoint(m_vertexId, m_vertexPosition.x(), m_vertexPosition.y(), 0);
-			points->Modified();
-		}
-		m_targetPolygon->getVtkPolygon()->Modified();
-		m_targetPolygon->updateShapeData();
-		m_polygon->renderGraphicsView();
-	}
-	void undo() {
-		if (m_keyDown) {
-			// remove vertex.
-			vtkPoints* points = m_targetPolygon->getVtkPolygon()->GetPoints();
-			QVector<QVector2D> positions;
-			positions.reserve(points->GetNumberOfPoints());
-			double p[3];
-			for (vtkIdType i = 0; i < m_vertexId; ++i) {
-				points->GetPoint(i, p);
-				positions.append(QVector2D(p[0], p[1]));
-			}
-			// skip vertex in m_vertexId[
-			for (vtkIdType i = m_vertexId + 1; i < points->GetNumberOfPoints(); ++i) {
-				points->GetPoint(i, p);
-				positions.append(QVector2D(p[0], p[1]));
-			}
-			points->SetNumberOfPoints(positions.count());
-			for (vtkIdType i = 0; i < positions.count(); ++i) {
-				QVector2D v = positions.at(i);
-				points->SetPoint(i, v.x(), v.y(), 0);
-			}
-			points->Modified();
-			m_targetPolygon->getVtkPolygon()->Modified();
-			m_targetPolygon->updateShapeData();
-			m_polygon->renderGraphicsView();
-		} else {
-			// this never happens.
-		}
-	}
-	int id() const {
-		return iRIC::generateCommandId("GridCreatingConditionCompoundChannelAddPolygonVertex");
-	}
-	bool mergeWith(const QUndoCommand* other) {
-		const AddPolygonVertexCommand* comm = dynamic_cast<const AddPolygonVertexCommand*>(other);
-		if (comm == nullptr) {return false;}
-		if (comm->m_keyDown) {return false;}
-		if (m_polygon != comm->m_polygon) {return false;}
-		if (m_vertexId != comm->m_vertexId) {return false;}
-		m_vertexPosition = comm->m_vertexPosition;
-		return true;
-	}
-private:
-	bool m_keyDown;
-	vtkIdType m_vertexId;
-	QVector2D m_vertexPosition;
-	GridCreatingConditionCompoundChannel* m_polygon;
-	GridCreatingConditionCompoundChannelAbstractPolygon* m_targetPolygon;
-};
 
 class GridCreatingConditionCompoundChannel::DefinePolyLineNewPointCommand : public QUndoCommand
 {
@@ -660,7 +565,7 @@ void GridCreatingConditionCompoundChannel::mouseMoveEvent(QMouseEvent* event, Pr
 				m_currentPoint = QPoint(event->x(), event->y());
 				break;
 			case meAddVertex:
-				iRICUndoStack::instance().push(new AddPolygonVertexCommand(false, m_selectedPolygon->selectedEdgeId(), QPoint(event->x(), event->y()), this));
+				pushRenderCommand(new AddPolygonVertexCommand(false, m_selectedPolygon->selectedEdgeId(), QPoint(event->x(), event->y()), this));
 				break;
 			case meTranslateDialog:
 				break;
@@ -925,7 +830,7 @@ void GridCreatingConditionCompoundChannel::mousePressEvent(QMouseEvent* event, P
 					break;
 				case meAddVertexPrepare:
 					m_mouseEventMode = meAddVertex;
-					iRICUndoStack::instance().push(new AddPolygonVertexCommand(true, m_selectedPolygon->selectedEdgeId(), QPoint(event->x(), event->y()), this));
+					pushRenderCommand(new AddPolygonVertexCommand(true, m_selectedPolygon->selectedEdgeId(), QPoint(event->x(), event->y()), this));
 					break;
 				case meAddVertexNotPossible:
 					// do nothing.

--- a/libs/gridcreatingcondition/compoundchannel/gridcreatingconditioncompoundchannel.h
+++ b/libs/gridcreatingcondition/compoundchannel/gridcreatingconditioncompoundchannel.h
@@ -130,8 +130,7 @@ private slots:
 	void cancel() {m_canceled = true;}
 	void reverseCenterLine();
 
-protected:
-
+private:
 	void updateMouseCursor(PreProcessorGraphicsViewInterface* v);
 	void doLoadFromProjectMainFile(const QDomNode& node) override;
 	void doSaveToProjectMainFile(QXmlStreamWriter& writer) override;
@@ -141,8 +140,6 @@ protected:
 	void updateFilename() override {
 		setFilename("gridcreatingcondition.dat");
 	}
-
-private:
 
 	bool checkCondition();
 	bool selectObject(QPoint point);

--- a/libs/gridcreatingcondition/compoundchannel/gridcreatingconditioncompoundchannel.h
+++ b/libs/gridcreatingcondition/compoundchannel/gridcreatingconditioncompoundchannel.h
@@ -95,9 +95,9 @@ public:
 		meTranslateDialog,
 		meEditVerticesDialog
 	};
-	/// Constructor
 	GridCreatingConditionCompoundChannel(ProjectDataItem* parent, GridCreatingConditionCreator* creator);
 	virtual ~GridCreatingConditionCompoundChannel();
+
 	void setupMenu() override;
 	bool addToolBarButtons(QToolBar* /*parent*/) override;
 	void informSelection(PreProcessorGraphicsViewInterface* v) override;
@@ -114,10 +114,10 @@ public:
 	void assignActorZValues(const ZDepthRange& range) override;
 	void definePolygon(bool doubleClick);
 	void defineLine(bool doubleClick);
-	const QColor& color() const {return m_color;}
+	const QColor& color() const;
 	void setupScalarArray();
 	void clear() override;
-	bool ready() const override {return true;}
+	bool ready() const override;
 	bool create(QWidget* parent) override;
 	void update2Ds() override;
 	void showInitialDialog() override;
@@ -127,7 +127,7 @@ private slots:
 	void removeVertexMode(bool on);
 	void editCoordinates();
 	void restoreMouseEventMode();
-	void cancel() {m_canceled = true;}
+	void cancel();
 	void reverseCenterLine();
 
 private:
@@ -137,9 +137,7 @@ private:
 	void doApplyOffset(double x, double y) override;
 	void loadExternalData(const QString& filename) override;
 	void saveExternalData(const QString& filename) override;
-	void updateFilename() override {
-		setFilename("gridcreatingcondition.dat");
-	}
+	void updateFilename() override;
 
 	bool checkCondition();
 	bool selectObject(QPoint point);

--- a/libs/gridcreatingcondition/compoundchannel/gridcreatingconditioncompoundchannelabstractline.cpp
+++ b/libs/gridcreatingcondition/compoundchannel/gridcreatingconditioncompoundchannelabstractline.cpp
@@ -1,6 +1,7 @@
 #include "gridcreatingconditioncompoundchannel.h"
 #include "gridcreatingconditioncompoundchannelabstractline.h"
 
+#include <guibase/vtktool/vtkpointsutil.h>
 #include <misc/errormessage.h>
 
 #include <QPointF>
@@ -231,6 +232,38 @@ void GridCreatingConditionCompoundChannelAbstractLine::setZDepthRange(double /*m
 {
 	m_vertexActor->SetPosition(0, 0, max);
 	m_edgeActor->SetPosition(0, 0, max);
+}
+
+QPointF GridCreatingConditionCompoundChannelAbstractLine::vertex(int index) const
+{
+	double p[3];
+	getVtkLine()->GetPoints()->GetPoint(index, p);
+	return QPointF(p[0], p[1]);
+}
+
+void GridCreatingConditionCompoundChannelAbstractLine::insertVertex(int index, const QPointF& vertex)
+{
+	auto coords = vtkPointsUtil::getCoordinates(getVtkLine());
+	coords.insert(coords.begin() + index, vertex);
+	vtkPointsUtil::setCoordinates(getVtkLine(), coords);
+	updateShapeData();
+}
+
+void GridCreatingConditionCompoundChannelAbstractLine::setVertex(int index, const QPointF& vertex)
+{
+	auto line = getVtkLine();
+	line->GetPoints()->SetPoint(index, vertex.x(), vertex.y(), 0);
+	line->GetPoints()->Modified();
+	line->Modified();
+	updateShapeData();
+}
+
+void GridCreatingConditionCompoundChannelAbstractLine::removeVertex(int index)
+{
+	auto coords = vtkPointsUtil::getCoordinates(getVtkLine());
+	coords.erase(coords.begin() + index);
+	vtkPointsUtil::setCoordinates(getVtkLine(), coords);
+	updateShapeData();
 }
 
 void GridCreatingConditionCompoundChannelAbstractLine::setActive(bool active)

--- a/libs/gridcreatingcondition/compoundchannel/gridcreatingconditioncompoundchannelabstractline.h
+++ b/libs/gridcreatingcondition/compoundchannel/gridcreatingconditioncompoundchannelabstractline.h
@@ -41,6 +41,11 @@ public:
 	int selectedVertexId() const {return m_selectedVertexId;}
 	int selectedEdgeId() const {return m_selectedEdgeId;}
 
+	QPointF vertex(int index) const;
+	void insertVertex(int index, const QPointF& vertex);
+	void setVertex(int index, const QPointF& vertex);
+	void removeVertex(int index);
+
 	void setActive(bool active);
 	virtual void finishDefinition() {}
 	void reverseDirection();

--- a/libs/gridcreatingcondition/compoundchannel/gridcreatingconditioncompoundchannelabstractpolygon.cpp
+++ b/libs/gridcreatingcondition/compoundchannel/gridcreatingconditioncompoundchannelabstractpolygon.cpp
@@ -1,6 +1,7 @@
 #include "gridcreatingconditioncompoundchannel.h"
 #include "gridcreatingconditioncompoundchannelabstractpolygon.h"
 
+#include <guibase/vtktool/vtkpointsutil.h>
 #include <misc/errormessage.h>
 
 #include <QMap>
@@ -238,6 +239,38 @@ void GridCreatingConditionCompoundChannelAbstractPolygon::setZDepthRange(double 
 	m_vertexActor->SetPosition(0, 0, max);
 	m_edgeActor->SetPosition(0, 0, max);
 	m_paintActor->SetPosition(0, 0, min);
+}
+
+QPointF GridCreatingConditionCompoundChannelAbstractPolygon::vertex(int index) const
+{
+	double p[3];
+	getVtkPolygon()->GetPoints()->GetPoint(index, p);
+	return QPointF(p[0], p[1]);
+}
+
+void GridCreatingConditionCompoundChannelAbstractPolygon::insertVertex(int index, const QPointF& vertex)
+{
+	auto coords = vtkPointsUtil::getCoordinates(getVtkPolygon());
+	coords.insert(coords.begin() + index, vertex);
+	vtkPointsUtil::setCoordinates(getVtkPolygon(), coords);
+	updateShapeData();
+}
+
+void GridCreatingConditionCompoundChannelAbstractPolygon::setVertex(int index, const QPointF& vertex)
+{
+	auto pol = getVtkPolygon();
+	pol->GetPoints()->SetPoint(index, vertex.x(), vertex.y(), 0);
+	pol->GetPoints()->Modified();
+	pol->Modified();
+	updateShapeData();
+}
+
+void GridCreatingConditionCompoundChannelAbstractPolygon::removeVertex(int index)
+{
+	auto coords = vtkPointsUtil::getCoordinates(getVtkPolygon());
+	coords.erase(coords.begin() + index);
+	vtkPointsUtil::setCoordinates(getVtkPolygon(), coords);
+	updateShapeData();
 }
 
 void GridCreatingConditionCompoundChannelAbstractPolygon::setActive(bool active)

--- a/libs/gridcreatingcondition/compoundchannel/gridcreatingconditioncompoundchannelabstractpolygon.h
+++ b/libs/gridcreatingcondition/compoundchannel/gridcreatingconditioncompoundchannelabstractpolygon.h
@@ -22,7 +22,6 @@ public:
 	GridCreatingConditionCompoundChannelAbstractPolygon(GridCreatingConditionCompoundChannel* parent);
 	~GridCreatingConditionCompoundChannelAbstractPolygon();
 
-
 	bool isVertexSelectable(const QVector2D& pos, double distlimit);
 	bool isEdgeSelectable(const QVector2D& pos, double distlimit);
 	bool isPolygonSelectable(const QVector2D& pos);
@@ -34,6 +33,11 @@ public:
 	void updateShapeData();
 	int selectedVertexId() const {return m_selectedVertexId;}
 	int selectedEdgeId() const {return m_selectedEdgeId;}
+
+	QPointF vertex(int index) const;
+	void insertVertex(int index, const QPointF& vertex);
+	void setVertex(int index, const QPointF& vertex);
+	void removeVertex(int index);
 
 	void setActive(bool active);
 	QPointF innerPoint(QPointF offset = QPointF(0, 0)) const;

--- a/libs/gridcreatingcondition/compoundchannel/private/gridcreatingconditioncompoundchannel_addpolygonvertexcommand.cpp
+++ b/libs/gridcreatingcondition/compoundchannel/private/gridcreatingconditioncompoundchannel_addpolygonvertexcommand.cpp
@@ -1,0 +1,56 @@
+#include "gridcreatingconditioncompoundchannel_addpolygonvertexcommand.h"
+#include "../gridcreatingconditioncompoundchannelabstractpolygon.h"
+
+#include <guicore/misc/qundocommandhelper.h>
+#include <guicore/pre/base/preprocessorgraphicsviewinterface.h>
+
+GridCreatingConditionCompoundChannel::AddPolygonVertexCommand::AddPolygonVertexCommand(bool keyDown, vtkIdType edgeId, QPoint point, GridCreatingConditionCompoundChannel* cond) :
+	QUndoCommand {GridCreatingConditionCompoundChannel::tr("Insert Polygon Vertex")},
+	m_keyDown {keyDown},
+	m_targetPolygon {cond->m_selectedPolygon},
+	m_condition {cond}
+{
+	m_vertexId = (edgeId + 1) % (cond->m_selectedPolygon->getVtkPolygon()->GetNumberOfPoints() + 1);
+	double dx = point.x();
+	double dy = point.y();
+	cond->graphicsView()->viewportToWorld(dx, dy);
+	m_vertexPosition = QPointF(dx, dy);
+}
+
+void GridCreatingConditionCompoundChannel::AddPolygonVertexCommand::redo()
+{
+	if (m_keyDown) {
+		// add vertex
+		m_targetPolygon->insertVertex(m_vertexId, m_vertexPosition);
+	} else {
+		// just modify the vertex position
+		m_targetPolygon->setVertex(m_vertexId, m_vertexPosition);
+	}
+}
+
+void GridCreatingConditionCompoundChannel::AddPolygonVertexCommand::undo()
+{
+	if (m_keyDown) {
+		// remove vertex at m_vertexId
+		m_targetPolygon->removeVertex(m_vertexId);
+	} else {
+		// this never happens.
+	}
+}
+
+int GridCreatingConditionCompoundChannel::AddPolygonVertexCommand::id() const
+{
+	return iRIC::generateCommandId("GridCreatingConditionCompoundChannelAddPolygonVertex");
+}
+
+bool GridCreatingConditionCompoundChannel::AddPolygonVertexCommand::mergeWith(const QUndoCommand* other)
+{
+	const AddPolygonVertexCommand* comm = dynamic_cast<const AddPolygonVertexCommand*>(other);
+	if (comm == nullptr) {return false;}
+	if (comm->m_keyDown) {return false;}
+	if (m_vertexId != comm->m_vertexId) {return false;}
+	if (m_targetPolygon != comm->m_targetPolygon) {return false;}
+	if (m_condition != comm->m_condition) {return false;}
+	m_vertexPosition = comm->m_vertexPosition;
+	return true;
+}

--- a/libs/gridcreatingcondition/compoundchannel/private/gridcreatingconditioncompoundchannel_addpolygonvertexcommand.h
+++ b/libs/gridcreatingcondition/compoundchannel/private/gridcreatingconditioncompoundchannel_addpolygonvertexcommand.h
@@ -1,0 +1,26 @@
+#ifndef GRIDCREATINGCONDITIONCOMPOUNDCHANNEL_ADDPOLYGONVERTEXCOMMAND_H
+#define GRIDCREATINGCONDITIONCOMPOUNDCHANNEL_ADDPOLYGONVERTEXCOMMAND_H
+
+#include "../gridcreatingconditioncompoundchannel.h"
+
+#include <QUndoCommand>
+
+class GridCreatingConditionCompoundChannel::AddPolygonVertexCommand : public QUndoCommand
+{
+public:
+	AddPolygonVertexCommand(bool keyDown, vtkIdType edgeId, QPoint point, GridCreatingConditionCompoundChannel* cond);
+
+	void redo() override;
+	void undo() override;
+	int id() const override;
+	bool mergeWith(const QUndoCommand* other) override;
+
+private:
+	bool m_keyDown;
+	vtkIdType m_vertexId;
+	QPointF m_vertexPosition;
+	GridCreatingConditionCompoundChannelAbstractPolygon* m_targetPolygon;
+	GridCreatingConditionCompoundChannel* m_condition;
+};
+
+#endif // GRIDCREATINGCONDITIONCOMPOUNDCHANNEL_ADDPOLYGONVERTEXCOMMAND_H

--- a/libs/gridcreatingcondition/compoundchannel/private/gridcreatingconditioncompoundchannel_addpolylinevertexcommand.cpp
+++ b/libs/gridcreatingcondition/compoundchannel/private/gridcreatingconditioncompoundchannel_addpolylinevertexcommand.cpp
@@ -1,0 +1,56 @@
+#include "gridcreatingconditioncompoundchannel_addpolylinevertexcommand.h"
+#include "../gridcreatingconditioncompoundchannelabstractline.h"
+
+#include <guicore/misc/qundocommandhelper.h>
+#include <guicore/pre/base/preprocessorgraphicsviewinterface.h>
+
+GridCreatingConditionCompoundChannel::AddPolyLineVertexCommand::AddPolyLineVertexCommand(bool keyDown, vtkIdType edgeId, QPoint point, GridCreatingConditionCompoundChannel* cond) :
+	QUndoCommand {GridCreatingConditionCompoundChannel::tr("Insert Polygonal Line Vertex")},
+	m_keyDown {keyDown},
+	m_vertexId {edgeId + 1},
+	m_targetLine {cond->m_selectedLine},
+	m_condition {cond}
+{
+	double dx = point.x();
+	double dy = point.y();
+	cond->graphicsView()->viewportToWorld(dx, dy);
+	m_vertexPosition = QPointF(dx, dy);
+}
+
+void GridCreatingConditionCompoundChannel::AddPolyLineVertexCommand::redo()
+{
+	if (m_keyDown) {
+		// add vertex.
+		m_targetLine->insertVertex(m_vertexId, m_vertexPosition);
+	} else {
+		// just modify the vertex position
+		m_targetLine->setVertex(m_vertexId, m_vertexPosition);
+	}
+}
+
+void GridCreatingConditionCompoundChannel::AddPolyLineVertexCommand::undo()
+{
+	if (m_keyDown) {
+		// remove vertex.
+		m_targetLine->removeVertex(m_vertexId);
+	} else {
+		// this never happens.
+	}
+}
+
+int GridCreatingConditionCompoundChannel::AddPolyLineVertexCommand::id() const
+{
+	return iRIC::generateCommandId("GridCreatingConditionCompoundChannelAddPolyLineVertex");
+}
+
+bool GridCreatingConditionCompoundChannel::AddPolyLineVertexCommand::mergeWith(const QUndoCommand* other)
+{
+	const AddPolyLineVertexCommand* comm = dynamic_cast<const AddPolyLineVertexCommand*>(other);
+	if (comm == nullptr) {return false;}
+	if (comm->m_keyDown) {return false;}
+	if (m_targetLine != comm->m_targetLine) {return false;}
+	if (m_condition != comm->m_condition) {return false;}
+	if (m_vertexId != comm->m_vertexId) {return false;}
+	m_vertexPosition = comm->m_vertexPosition;
+	return true;
+}

--- a/libs/gridcreatingcondition/compoundchannel/private/gridcreatingconditioncompoundchannel_addpolylinevertexcommand.h
+++ b/libs/gridcreatingcondition/compoundchannel/private/gridcreatingconditioncompoundchannel_addpolylinevertexcommand.h
@@ -1,0 +1,27 @@
+#ifndef GRIDCREATINGCONDITIONCOMPOUNDCHANNEL_ADDPOLYLINEVERTEXCOMMAND_H
+#define GRIDCREATINGCONDITIONCOMPOUNDCHANNEL_ADDPOLYLINEVERTEXCOMMAND_H
+
+#include "../gridcreatingconditioncompoundchannel.h"
+
+#include <QUndoCommand>
+
+class GridCreatingConditionCompoundChannel::AddPolyLineVertexCommand : public QUndoCommand
+{
+public:
+	AddPolyLineVertexCommand(bool keyDown, vtkIdType edgeId, QPoint point, GridCreatingConditionCompoundChannel* cond);
+
+	void redo() override;
+	void undo() override;
+	int id() const override;
+	bool mergeWith(const QUndoCommand* other) override;
+
+private:
+	bool m_keyDown;
+	vtkIdType m_vertexId;
+	QPointF m_vertexPosition;
+	GridCreatingConditionCompoundChannelAbstractLine* m_targetLine;
+	GridCreatingConditionCompoundChannel* m_condition;
+};
+
+
+#endif // GRIDCREATINGCONDITIONCOMPOUNDCHANNEL_ADDPOLYLINEVERTEXCOMMAND_H

--- a/libs/gridcreatingcondition/compoundchannel/private/gridcreatingconditioncompoundchannel_definepolygonnewpointcommand.cpp
+++ b/libs/gridcreatingcondition/compoundchannel/private/gridcreatingconditioncompoundchannel_definepolygonnewpointcommand.cpp
@@ -1,0 +1,58 @@
+#include "gridcreatingconditioncompoundchannel_definepolygonnewpointcommand.h"
+#include "../gridcreatingconditioncompoundchannelabstractpolygon.h"
+
+#include <guicore/misc/qundocommandhelper.h>
+#include <guicore/pre/base/preprocessorgraphicsviewinterface.h>
+
+GridCreatingConditionCompoundChannel::DefinePolygonNewPointCommand::DefinePolygonNewPointCommand(bool keyDown, const QPoint& point, GridCreatingConditionCompoundChannel* cond) :
+	QUndoCommand {GridCreatingConditionCompoundChannel::tr("Add New Polygon Point")},
+	m_keyDown {keyDown},
+	m_targetPolygon {cond->m_selectedPolygon},
+	m_condition {cond}
+{
+	double dx = point.x();
+	double dy = point.y();
+	cond->graphicsView()->viewportToWorld(dx, dy);
+	m_newPoint = QPointF(dx, dy);
+}
+
+void GridCreatingConditionCompoundChannel::DefinePolygonNewPointCommand::redo()
+{
+	if (m_keyDown) {
+		// add new point.
+		vtkIdType num = m_targetPolygon->getVtkPolygon()->GetNumberOfPoints();
+		m_targetPolygon->insertVertex(num, m_newPoint);
+	} else {
+		// modify the last point.
+		vtkIdType num = m_targetPolygon->getVtkPolygon()->GetNumberOfPoints();
+		m_targetPolygon->setVertex(num - 1, m_newPoint);
+	}
+}
+
+void GridCreatingConditionCompoundChannel::DefinePolygonNewPointCommand::undo()
+{
+	vtkPolygon* pol = m_targetPolygon->getVtkPolygon();
+	if (m_keyDown) {
+		// remove the last point
+		vtkIdType num = m_targetPolygon->getVtkPolygon()->GetNumberOfPoints();
+		m_targetPolygon->removeVertex(num - 1);
+	} else {
+		// this does not happen. no implementation needed.
+	}
+}
+
+int GridCreatingConditionCompoundChannel::DefinePolygonNewPointCommand::id() const
+{
+	return iRIC::generateCommandId("GridCreatingConditionCompoundChannelPolygonDefineNewPoint");
+}
+
+bool GridCreatingConditionCompoundChannel::DefinePolygonNewPointCommand::mergeWith(const QUndoCommand* other)
+{
+	const DefinePolygonNewPointCommand* comm = dynamic_cast<const DefinePolygonNewPointCommand*>(other);
+	if (comm == nullptr) {return false;}
+	if (comm->m_keyDown) {return false;}
+	if (comm->m_targetPolygon != m_targetPolygon) {return false;}
+	if (comm->m_condition != m_condition) {return false;}
+	m_newPoint = comm->m_newPoint;
+	return true;
+}

--- a/libs/gridcreatingcondition/compoundchannel/private/gridcreatingconditioncompoundchannel_definepolygonnewpointcommand.h
+++ b/libs/gridcreatingcondition/compoundchannel/private/gridcreatingconditioncompoundchannel_definepolygonnewpointcommand.h
@@ -1,0 +1,25 @@
+#ifndef GRIDCREATINGCONDITIONCOMPOUNDCHANNEL_DEFINEPOLYGONNEWPOINTCOMMAND_H
+#define GRIDCREATINGCONDITIONCOMPOUNDCHANNEL_DEFINEPOLYGONNEWPOINTCOMMAND_H
+
+#include "../gridcreatingconditioncompoundchannel.h"
+
+#include <QUndoCommand>
+
+class GridCreatingConditionCompoundChannel::DefinePolygonNewPointCommand : public QUndoCommand
+{
+public:
+	DefinePolygonNewPointCommand(bool keyDown, const QPoint& point, GridCreatingConditionCompoundChannel* cond);
+
+	void redo() override;
+	void undo() override;
+	int id() const override;
+	bool mergeWith(const QUndoCommand* other) override;
+
+private:
+	bool m_keyDown;
+	GridCreatingConditionCompoundChannelAbstractPolygon* m_targetPolygon;
+	GridCreatingConditionCompoundChannel* m_condition;
+	QPointF m_newPoint;
+};
+
+#endif // GRIDCREATINGCONDITIONCOMPOUNDCHANNEL_DEFINEPOLYGONNEWPOINTCOMMAND_H

--- a/libs/gridcreatingcondition/compoundchannel/private/gridcreatingconditioncompoundchannel_definepolylinenewpointcommand.cpp
+++ b/libs/gridcreatingcondition/compoundchannel/private/gridcreatingconditioncompoundchannel_definepolylinenewpointcommand.cpp
@@ -1,0 +1,61 @@
+#include "gridcreatingconditioncompoundchannel_definepolylinenewpointcommand.h"
+#include "../gridcreatingconditioncompoundchannelabstractline.h"
+
+#include <guicore/misc/qundocommandhelper.h>
+#include <guicore/pre/base/preprocessorgraphicsviewinterface.h>
+
+GridCreatingConditionCompoundChannel::DefinePolyLineNewPointCommand::DefinePolyLineNewPointCommand(bool keyDown, const QPoint& point, GridCreatingConditionCompoundChannel* cond) :
+	QUndoCommand {GridCreatingConditionCompoundChannel::tr("Add New Center Line Point")},
+	m_keyDown {keyDown},
+	m_targetLine {cond->m_selectedLine},
+	m_condition {cond}
+{
+	double dx = point.x();
+	double dy = point.y();
+	cond->graphicsView()->viewportToWorld(dx, dy);
+	m_newPoint = QPointF(dx, dy);
+}
+
+void GridCreatingConditionCompoundChannel::DefinePolyLineNewPointCommand::redo()
+{
+	if (m_keyDown) {
+		// add new point.
+		vtkIdType num = m_targetLine->getVtkLine()->GetNumberOfPoints();
+		m_targetLine->insertVertex(num, m_newPoint);
+		if (num == 0) {
+			m_condition->m_mouseEventMode = GridCreatingConditionCompoundChannel::meDefining;
+		}
+	} else {
+		// modify the last point.
+		vtkIdType num = m_targetLine->getVtkLine()->GetNumberOfPoints();
+		m_targetLine->setVertex(num - 1, m_newPoint);
+	}
+}
+
+void GridCreatingConditionCompoundChannel::DefinePolyLineNewPointCommand::undo() {
+	vtkPolyLine* line = m_targetLine->getVtkLine();
+	if (m_keyDown) {
+		// remove the last point.
+		vtkIdType num = m_targetLine->getVtkLine()->GetNumberOfPoints();
+		m_targetLine->removeVertex(num - 1);
+		if (num == 1) {
+			m_condition->m_mouseEventMode = GridCreatingConditionCompoundChannel::meBeforeDefining;
+		}
+	} else {
+		// this does not happen. no implementation needed.
+	}
+}
+
+int GridCreatingConditionCompoundChannel::DefinePolyLineNewPointCommand::id() const {
+	return iRIC::generateCommandId("GridCreatingConditionCompoundChannelDefinePolyLineNewPoint");
+}
+
+bool GridCreatingConditionCompoundChannel::DefinePolyLineNewPointCommand::mergeWith(const QUndoCommand* other) {
+	const DefinePolyLineNewPointCommand* comm = dynamic_cast<const DefinePolyLineNewPointCommand*>(other);
+	if (comm == nullptr) {return false;}
+	if (comm->m_keyDown) {return false;}
+	if (comm->m_targetLine != m_targetLine) {return false;}
+	if (comm->m_condition != m_condition) {return false;}
+	m_newPoint = comm->m_newPoint;
+	return true;
+}

--- a/libs/gridcreatingcondition/compoundchannel/private/gridcreatingconditioncompoundchannel_definepolylinenewpointcommand.h
+++ b/libs/gridcreatingcondition/compoundchannel/private/gridcreatingconditioncompoundchannel_definepolylinenewpointcommand.h
@@ -1,0 +1,25 @@
+#ifndef GRIDCREATINGCONDITIONCOMPOUNDCHANNEL_DEFINEPOLYLINENEWPOINTCOMMAND_H
+#define GRIDCREATINGCONDITIONCOMPOUNDCHANNEL_DEFINEPOLYLINENEWPOINTCOMMAND_H
+
+#include "../gridcreatingconditioncompoundchannel.h"
+
+#include <QUndoCommand>
+
+class GridCreatingConditionCompoundChannel::DefinePolyLineNewPointCommand : public QUndoCommand
+{
+public:
+	DefinePolyLineNewPointCommand(bool keyDown, const QPoint& point, GridCreatingConditionCompoundChannel* cond);
+
+	void redo() override;
+	void undo() override;
+	int id() const override;
+	bool mergeWith(const QUndoCommand* other) override;
+
+private:
+	bool m_keyDown;
+	GridCreatingConditionCompoundChannelAbstractLine* m_targetLine;
+	GridCreatingConditionCompoundChannel* m_condition;
+	QPointF m_newPoint;
+};
+
+#endif // GRIDCREATINGCONDITIONCOMPOUNDCHANNEL_DEFINEPOLYLINENEWPOINTCOMMAND_H

--- a/libs/gridcreatingcondition/compoundchannel/private/gridcreatingconditioncompoundchannel_movepolygoncommand.cpp
+++ b/libs/gridcreatingcondition/compoundchannel/private/gridcreatingconditioncompoundchannel_movepolygoncommand.cpp
@@ -1,0 +1,66 @@
+#include "gridcreatingconditioncompoundchannel_movepolygoncommand.h"
+#include "../gridcreatingconditioncompoundchannelabstractpolygon.h"
+
+#include <guicore/misc/qundocommandhelper.h>
+#include <guicore/pre/base/preprocessorgraphicsviewinterface.h>
+
+GridCreatingConditionCompoundChannel::MovePolygonCommand::MovePolygonCommand(bool keyDown, const QPoint& from, const QPoint& to, GridCreatingConditionCompoundChannel* cond) :
+	QUndoCommand {GridCreatingConditionCompoundChannel::tr("Move Polygon")},
+	m_keyDown {keyDown},
+	m_targetPolygon {cond->m_selectedPolygon},
+	m_condition {cond}
+{
+	double dx = from.x();
+	double dy = from.y();
+	cond->graphicsView()->viewportToWorld(dx, dy);
+	QPointF fromVec(dx, dy);
+
+	dx = to.x();
+	dy = to.y();
+	cond->graphicsView()->viewportToWorld(dx, dy);
+	QPointF toVec(dx, dy);
+
+	m_offset = toVec - fromVec;
+}
+
+void GridCreatingConditionCompoundChannel::MovePolygonCommand::redo()
+{
+	applyOffset(m_offset);
+}
+
+void GridCreatingConditionCompoundChannel::MovePolygonCommand::undo()
+{
+	applyOffset(- m_offset);
+}
+
+void GridCreatingConditionCompoundChannel::MovePolygonCommand::applyOffset(const QPointF& offset)
+{
+	vtkPolygon* pol = m_targetPolygon->getVtkPolygon();
+	vtkPoints* points = pol->GetPoints();
+	for (vtkIdType i = 0; i < points->GetNumberOfPoints(); ++i) {
+		double p[3];
+		points->GetPoint(i, p);
+		p[0] += offset.x();
+		p[1] += offset.y();
+		points->SetPoint(i, p);
+	}
+	points->Modified();
+	pol->Modified();
+	m_targetPolygon->updateShapeData();
+}
+
+int GridCreatingConditionCompoundChannel::MovePolygonCommand::id() const
+{
+	return iRIC::generateCommandId("GridCreatingConditionCompoundChannelMovePolygonCommand");
+}
+
+bool GridCreatingConditionCompoundChannel::MovePolygonCommand::mergeWith(const QUndoCommand* other)
+{
+	const MovePolygonCommand* comm = dynamic_cast<const MovePolygonCommand*>(other);
+	if (comm == nullptr) {return false;}
+	if (comm->m_keyDown) {return false;}
+	if (comm->m_targetPolygon != m_targetPolygon) {return false;}
+	if (comm->m_condition != m_condition) {return false;}
+	m_offset += comm->m_offset;
+	return true;
+}

--- a/libs/gridcreatingcondition/compoundchannel/private/gridcreatingconditioncompoundchannel_movepolygoncommand.h
+++ b/libs/gridcreatingcondition/compoundchannel/private/gridcreatingconditioncompoundchannel_movepolygoncommand.h
@@ -1,0 +1,27 @@
+#ifndef GRIDCREATINGCONDITIONCOMPOUNDCHANNEL_MOVEPOLYGONCOMMAND_H
+#define GRIDCREATINGCONDITIONCOMPOUNDCHANNEL_MOVEPOLYGONCOMMAND_H
+
+#include "../gridcreatingconditioncompoundchannel.h"
+
+#include <QUndoCommand>
+
+class GridCreatingConditionCompoundChannel::MovePolygonCommand : public QUndoCommand
+{
+public:
+	MovePolygonCommand(bool keyDown, const QPoint& from, const QPoint& to, GridCreatingConditionCompoundChannel* cond);
+
+	void redo() override;
+	void undo() override;
+	int id() const override;
+	bool mergeWith(const QUndoCommand* other) override;
+
+private:
+	void applyOffset(const QPointF& offset);
+
+	bool m_keyDown;
+	GridCreatingConditionCompoundChannelAbstractPolygon* m_targetPolygon;
+	GridCreatingConditionCompoundChannel* m_condition;
+	QPointF m_offset;
+};
+
+#endif // GRIDCREATINGCONDITIONCOMPOUNDCHANNEL_MOVEPOLYGONCOMMAND_H

--- a/libs/gridcreatingcondition/compoundchannel/private/gridcreatingconditioncompoundchannel_movepolygonvertexcommand.cpp
+++ b/libs/gridcreatingcondition/compoundchannel/private/gridcreatingconditioncompoundchannel_movepolygonvertexcommand.cpp
@@ -1,0 +1,57 @@
+#include "gridcreatingconditioncompoundchannel_movepolygonvertexcommand.h"
+#include "../gridcreatingconditioncompoundchannelabstractpolygon.h"
+
+#include <guicore/misc/qundocommandhelper.h>
+#include <guicore/pre/base/preprocessorgraphicsviewinterface.h>
+
+GridCreatingConditionCompoundChannel::MovePolygonVertexCommand::MovePolygonVertexCommand(bool keyDown, const QPoint& from, const QPoint& to, vtkIdType vertexId, GridCreatingConditionCompoundChannel* cond) :
+	QUndoCommand {GridCreatingConditionCompoundChannel::tr("Move Polygon Vertex")},
+	m_keyDown {keyDown},
+	m_vertexId {vertexId},
+	m_targetPolygon {cond->m_selectedPolygon},
+	m_condition {cond}
+{
+	double dx = from.x();
+	double dy = from.y();
+	cond->graphicsView()->viewportToWorld(dx, dy);
+	QPointF fromVec(dx, dy);
+	dx = to.x();
+	dy = to.y();
+	cond->graphicsView()->viewportToWorld(dx, dy);
+	QPointF toVec(dx, dy);
+	m_offset = toVec - fromVec;
+}
+
+void GridCreatingConditionCompoundChannel::MovePolygonVertexCommand::redo()
+{
+	applyOffset(m_offset);
+}
+
+void GridCreatingConditionCompoundChannel::MovePolygonVertexCommand::undo()
+{
+	applyOffset(- m_offset);
+}
+
+int GridCreatingConditionCompoundChannel::MovePolygonVertexCommand::id() const
+{
+	return iRIC::generateCommandId("GridCreatingConditionCompoundChannelPolygonMoveVertex");
+}
+
+bool GridCreatingConditionCompoundChannel::MovePolygonVertexCommand::mergeWith(const QUndoCommand* other)
+{
+	const MovePolygonVertexCommand* comm = dynamic_cast<const MovePolygonVertexCommand*>(other);
+	if (comm == nullptr) {return false;}
+	if (comm->m_keyDown) {return false;}
+	if (comm->m_vertexId != m_vertexId) {return false;}
+	if (comm->m_targetPolygon != m_targetPolygon) {return false;}
+	if (comm->m_condition != m_condition) {return false;}
+	m_offset += comm->m_offset;
+	return true;
+}
+
+void GridCreatingConditionCompoundChannel::MovePolygonVertexCommand::applyOffset(const QPointF& offset)
+{
+	QPointF p = m_targetPolygon->vertex(m_vertexId);
+	p += offset;
+	m_targetPolygon->setVertex(m_vertexId, p);
+}

--- a/libs/gridcreatingcondition/compoundchannel/private/gridcreatingconditioncompoundchannel_movepolygonvertexcommand.h
+++ b/libs/gridcreatingcondition/compoundchannel/private/gridcreatingconditioncompoundchannel_movepolygonvertexcommand.h
@@ -1,0 +1,28 @@
+#ifndef GRIDCREATINGCONDITIONCOMPOUNDCHANNEL_MOVEPOLYGONVERTEXCOMMAND_H
+#define GRIDCREATINGCONDITIONCOMPOUNDCHANNEL_MOVEPOLYGONVERTEXCOMMAND_H
+
+#include "../gridcreatingconditioncompoundchannel.h"
+
+#include <QUndoCommand>
+
+class GridCreatingConditionCompoundChannel::MovePolygonVertexCommand : public QUndoCommand
+{
+public:
+	MovePolygonVertexCommand(bool keyDown, const QPoint& from, const QPoint& to, vtkIdType vertexId, GridCreatingConditionCompoundChannel* cond);
+
+	void redo() override;
+	void undo() override;
+	int id() const override;
+	bool mergeWith(const QUndoCommand* other) override;
+
+private:
+	void applyOffset(const QPointF& offset);
+
+	bool m_keyDown;
+	vtkIdType m_vertexId;
+	GridCreatingConditionCompoundChannelAbstractPolygon* m_targetPolygon;
+	GridCreatingConditionCompoundChannel* m_condition;
+	QPointF m_offset;
+};
+
+#endif // GRIDCREATINGCONDITIONCOMPOUNDCHANNEL_MOVEPOLYGONVERTEXCOMMAND_H

--- a/libs/gridcreatingcondition/compoundchannel/private/gridcreatingconditioncompoundchannel_movepolylinecommand.cpp
+++ b/libs/gridcreatingcondition/compoundchannel/private/gridcreatingconditioncompoundchannel_movepolylinecommand.cpp
@@ -1,0 +1,64 @@
+#include "gridcreatingconditioncompoundchannel_movepolylinecommand.h"
+#include "../gridcreatingconditioncompoundchannelabstractline.h"
+
+#include <guicore/misc/qundocommandhelper.h>
+#include <guicore/pre/base/preprocessorgraphicsviewinterface.h>
+
+GridCreatingConditionCompoundChannel::MovePolyLineCommand::MovePolyLineCommand(bool keyDown, const QPoint& from, const QPoint& to, GridCreatingConditionCompoundChannel* cond) :
+	QUndoCommand {GridCreatingConditionCompoundChannel::tr("Move Polygonal Line")},
+	m_keyDown {keyDown},
+	m_targetLine {cond->m_selectedLine},
+	m_condition {cond}
+{
+	double dx = from.x();
+	double dy = from.y();
+	cond->graphicsView()->viewportToWorld(dx, dy);
+	QPointF fromVec(dx, dy);
+	dx = to.x();
+	dy = to.y();
+	cond->graphicsView()->viewportToWorld(dx, dy);
+	QPointF toVec(dx, dy);
+	m_offset = toVec - fromVec;
+}
+
+void GridCreatingConditionCompoundChannel::MovePolyLineCommand::redo()
+{
+	applyOffset(m_offset);
+}
+
+void GridCreatingConditionCompoundChannel::MovePolyLineCommand::undo()
+{
+	applyOffset(-m_offset);
+}
+
+int GridCreatingConditionCompoundChannel::MovePolyLineCommand::id() const
+{
+	return iRIC::generateCommandId("GridCreatingConditionCompoundChannelMovePolyLine");
+}
+
+bool GridCreatingConditionCompoundChannel::MovePolyLineCommand::mergeWith(const QUndoCommand* other)
+{
+	const MovePolyLineCommand* comm = dynamic_cast<const MovePolyLineCommand*>(other);
+	if (comm == nullptr) {return false;}
+	if (comm->m_keyDown) {return false;}
+	if (comm->m_targetLine != m_targetLine) {return false;}
+	if (comm->m_condition != m_condition) {return false;}
+	m_offset += comm->m_offset;
+	return true;
+}
+
+void GridCreatingConditionCompoundChannel::MovePolyLineCommand::applyOffset(const QPointF& offset)
+{
+	vtkPolyLine* pol = m_targetLine->getVtkLine();
+	vtkPoints* points = pol->GetPoints();
+	for (vtkIdType i = 0; i < points->GetNumberOfPoints(); ++i) {
+		double p[3];
+		points->GetPoint(i, p);
+		p[0] += offset.x();
+		p[1] += offset.y();
+		points->SetPoint(i, p);
+	}
+	points->Modified();
+	pol->Modified();
+	m_targetLine->updateShapeData();
+}

--- a/libs/gridcreatingcondition/compoundchannel/private/gridcreatingconditioncompoundchannel_movepolylinecommand.h
+++ b/libs/gridcreatingcondition/compoundchannel/private/gridcreatingconditioncompoundchannel_movepolylinecommand.h
@@ -1,0 +1,27 @@
+#ifndef GRIDCREATINGCONDITIONCOMPOUNDCHANNEL_MOVEPOLYLINECOMMAND_H
+#define GRIDCREATINGCONDITIONCOMPOUNDCHANNEL_MOVEPOLYLINECOMMAND_H
+
+#include "../gridcreatingconditioncompoundchannel.h"
+
+#include <QUndoCommand>
+
+class GridCreatingConditionCompoundChannel::MovePolyLineCommand : public QUndoCommand
+{
+public:
+	MovePolyLineCommand(bool keyDown, const QPoint& from, const QPoint& to, GridCreatingConditionCompoundChannel* cond);
+
+	void redo() override;
+	void undo() override;
+	int id() const override;
+	bool mergeWith(const QUndoCommand* other) override;
+
+private:
+	void applyOffset(const QPointF& offset);
+
+	bool m_keyDown;
+	GridCreatingConditionCompoundChannelAbstractLine* m_targetLine;
+	GridCreatingConditionCompoundChannel* m_condition;
+	QPointF m_offset;
+};
+
+#endif // GRIDCREATINGCONDITIONCOMPOUNDCHANNEL_MOVEPOLYLINECOMMAND_H

--- a/libs/gridcreatingcondition/compoundchannel/private/gridcreatingconditioncompoundchannel_movepolylinevertexcommand.cpp
+++ b/libs/gridcreatingcondition/compoundchannel/private/gridcreatingconditioncompoundchannel_movepolylinevertexcommand.cpp
@@ -1,0 +1,57 @@
+#include "gridcreatingconditioncompoundchannel_movepolylinevertexcommand.h"
+#include "../gridcreatingconditioncompoundchannelabstractline.h"
+
+#include <guicore/misc/qundocommandhelper.h>
+#include <guicore/pre/base/preprocessorgraphicsviewinterface.h>
+
+GridCreatingConditionCompoundChannel::MovePolyLineVertexCommand::MovePolyLineVertexCommand(bool keyDown, const QPoint& from, const QPoint& to, vtkIdType vertexId, GridCreatingConditionCompoundChannel* cond) :
+	QUndoCommand {GridCreatingConditionCompoundChannel::tr("Move Polygonal Line Vertex")},
+	m_keyDown {keyDown},
+	m_vertexId {vertexId},
+	m_targetLine {cond->m_selectedLine},
+	m_condition {cond}
+{
+	double dx = from.x();
+	double dy = from.y();
+	cond->graphicsView()->viewportToWorld(dx, dy);
+	QPointF fromVec(dx, dy);
+	dx = to.x();
+	dy = to.y();
+	cond->graphicsView()->viewportToWorld(dx, dy);
+	QPointF toVec(dx, dy);
+	m_offset = toVec - fromVec;
+}
+
+void GridCreatingConditionCompoundChannel::MovePolyLineVertexCommand::redo()
+{
+	applyOffset(m_offset);
+}
+
+void GridCreatingConditionCompoundChannel::MovePolyLineVertexCommand::undo()
+{
+	applyOffset(- m_offset);
+}
+
+int GridCreatingConditionCompoundChannel::MovePolyLineVertexCommand::id() const
+{
+	return iRIC::generateCommandId("GridCreatingConditionCompoundChannelPolyLineMoveVertex");
+}
+
+bool GridCreatingConditionCompoundChannel::MovePolyLineVertexCommand::mergeWith(const QUndoCommand* other)
+{
+	const MovePolyLineVertexCommand* comm = dynamic_cast<const MovePolyLineVertexCommand*>(other);
+	if (comm == nullptr) {return false;}
+	if (comm->m_keyDown) {return false;}
+	if (comm->m_targetLine != m_targetLine) {return false;}
+	if (comm->m_condition != m_condition) {return false;}
+	if (comm->m_vertexId != m_vertexId) {return false;}
+	m_offset += comm->m_offset;
+	return true;
+}
+
+void GridCreatingConditionCompoundChannel::MovePolyLineVertexCommand::applyOffset(const QPointF& offset)
+{
+	QPointF p = m_targetLine->vertex(m_vertexId);
+	p += offset;
+	m_targetLine->setVertex(m_vertexId, p);
+}

--- a/libs/gridcreatingcondition/compoundchannel/private/gridcreatingconditioncompoundchannel_movepolylinevertexcommand.h
+++ b/libs/gridcreatingcondition/compoundchannel/private/gridcreatingconditioncompoundchannel_movepolylinevertexcommand.h
@@ -1,0 +1,28 @@
+#ifndef GRIDCREATINGCONDITIONCOMPOUNDCHANNEL_MOVEPOLYLINEVERTEXCOMMAND_H
+#define GRIDCREATINGCONDITIONCOMPOUNDCHANNEL_MOVEPOLYLINEVERTEXCOMMAND_H
+
+#include "../gridcreatingconditioncompoundchannel.h"
+
+#include <QUndoCommand>
+
+class GridCreatingConditionCompoundChannel::MovePolyLineVertexCommand : public QUndoCommand
+{
+public:
+	MovePolyLineVertexCommand(bool keyDown, const QPoint& from, const QPoint& to, vtkIdType vertexId, GridCreatingConditionCompoundChannel* cond);
+
+	void redo() override;
+	void undo() override;
+	int id() const override;
+	bool mergeWith(const QUndoCommand* other) override;
+
+private:
+	void applyOffset(const QPointF& offset);
+
+	bool m_keyDown;
+	vtkIdType m_vertexId;
+	QPointF m_offset;
+	GridCreatingConditionCompoundChannelAbstractLine* m_targetLine;
+	GridCreatingConditionCompoundChannel* m_condition;
+};
+
+#endif // GRIDCREATINGCONDITIONCOMPOUNDCHANNEL_MOVEPOLYLINEVERTEXCOMMAND_H

--- a/libs/gridcreatingcondition/compoundchannel/private/gridcreatingconditioncompoundchannel_removepolygonvertexcommand.cpp
+++ b/libs/gridcreatingcondition/compoundchannel/private/gridcreatingconditioncompoundchannel_removepolygonvertexcommand.cpp
@@ -1,0 +1,20 @@
+#include "gridcreatingconditioncompoundchannel_removepolygonvertexcommand.h"
+#include "../gridcreatingconditioncompoundchannelabstractpolygon.h"
+
+GridCreatingConditionCompoundChannel::RemovePolygonVertexCommand::RemovePolygonVertexCommand(vtkIdType vertexId, GridCreatingConditionCompoundChannel* cond) :
+	QUndoCommand {GridCreatingConditionCompoundChannel::tr("Remove Polygon Vertex")},
+	m_vertexId {vertexId},
+	m_vertexPosition {cond->m_selectedPolygon->vertex(m_vertexId)},
+	m_targetPolygon {cond->m_selectedPolygon},
+	m_condition {cond}
+{}
+
+void GridCreatingConditionCompoundChannel::RemovePolygonVertexCommand::redo()
+{
+	m_targetPolygon->removeVertex(m_vertexId);
+	m_condition->m_mouseEventMode = GridCreatingConditionCompoundChannel::meNormal;
+}
+
+void GridCreatingConditionCompoundChannel::RemovePolygonVertexCommand::undo() {
+	m_targetPolygon->insertVertex(m_vertexId, m_vertexPosition);
+}

--- a/libs/gridcreatingcondition/compoundchannel/private/gridcreatingconditioncompoundchannel_removepolygonvertexcommand.h
+++ b/libs/gridcreatingcondition/compoundchannel/private/gridcreatingconditioncompoundchannel_removepolygonvertexcommand.h
@@ -1,0 +1,23 @@
+#ifndef GRIDCREATINGCONDITIONCOMPOUNDCHANNEL_REMOVEPOLYGONVERTEXCOMMAND_H
+#define GRIDCREATINGCONDITIONCOMPOUNDCHANNEL_REMOVEPOLYGONVERTEXCOMMAND_H
+
+#include "../gridcreatingconditioncompoundchannel.h"
+
+#include <QUndoCommand>
+
+class GridCreatingConditionCompoundChannel::RemovePolygonVertexCommand : public QUndoCommand
+{
+public:
+	RemovePolygonVertexCommand(vtkIdType vertexId, GridCreatingConditionCompoundChannel* cond);
+
+	void redo() override;
+	void undo() override;
+
+private:
+	vtkIdType m_vertexId;
+	QPointF m_vertexPosition;
+	GridCreatingConditionCompoundChannelAbstractPolygon* m_targetPolygon;
+	GridCreatingConditionCompoundChannel* m_condition;
+};
+
+#endif // GRIDCREATINGCONDITIONCOMPOUNDCHANNEL_REMOVEPOLYGONVERTEXCOMMAND_H

--- a/libs/gridcreatingcondition/compoundchannel/private/gridcreatingconditioncompoundchannel_removepolylinevertexcommand.cpp
+++ b/libs/gridcreatingcondition/compoundchannel/private/gridcreatingconditioncompoundchannel_removepolylinevertexcommand.cpp
@@ -1,0 +1,21 @@
+#include "gridcreatingconditioncompoundchannel_removepolylinevertexcommand.h"
+#include "../gridcreatingconditioncompoundchannelabstractline.h"
+
+GridCreatingConditionCompoundChannel::RemovePolyLineVertexCommand::RemovePolyLineVertexCommand(vtkIdType vertexId, GridCreatingConditionCompoundChannel* cond) :
+	QUndoCommand {GridCreatingConditionCompoundChannel::tr("Remove Polygonal Line Vertex")},
+	m_vertexId {vertexId},
+	m_vertexPosition {cond->m_selectedLine->vertex(m_vertexId)},
+	m_targetLine {cond->m_selectedLine},
+	m_condition {cond}
+{}
+
+void GridCreatingConditionCompoundChannel::RemovePolyLineVertexCommand::redo()
+{
+	m_targetLine->removeVertex(m_vertexId);
+	m_condition->m_mouseEventMode = GridCreatingConditionCompoundChannel::meNormal;
+}
+
+void GridCreatingConditionCompoundChannel::RemovePolyLineVertexCommand::undo()
+{
+	m_targetLine->insertVertex(m_vertexId, m_vertexPosition);
+}

--- a/libs/gridcreatingcondition/compoundchannel/private/gridcreatingconditioncompoundchannel_removepolylinevertexcommand.h
+++ b/libs/gridcreatingcondition/compoundchannel/private/gridcreatingconditioncompoundchannel_removepolylinevertexcommand.h
@@ -1,0 +1,23 @@
+#ifndef GRIDCREATINGCONDITIONCOMPOUNDCHANNEL_REMOVEPOLYLINEVERTEXCOMMAND_H
+#define GRIDCREATINGCONDITIONCOMPOUNDCHANNEL_REMOVEPOLYLINEVERTEXCOMMAND_H
+
+#include "../gridcreatingconditioncompoundchannel.h"
+
+#include <QUndoCommand>
+
+class GridCreatingConditionCompoundChannel::RemovePolyLineVertexCommand : public QUndoCommand
+{
+public:
+	RemovePolyLineVertexCommand(vtkIdType vertexId, GridCreatingConditionCompoundChannel* cond);
+
+	void redo() override;
+	void undo() override;
+
+private:
+	vtkIdType m_vertexId;
+	QPointF m_vertexPosition;
+	GridCreatingConditionCompoundChannelAbstractLine* m_targetLine;
+	GridCreatingConditionCompoundChannel* m_condition;
+};
+
+#endif // GRIDCREATINGCONDITIONCOMPOUNDCHANNEL_REMOVEPOLYLINEVERTEXCOMMAND_H

--- a/libs/gridcreatingcondition/compoundchannel/private/gridcreatingconditioncompoundchannel_switchstatuscommand.cpp
+++ b/libs/gridcreatingcondition/compoundchannel/private/gridcreatingconditioncompoundchannel_switchstatuscommand.cpp
@@ -1,0 +1,74 @@
+#include "gridcreatingconditioncompoundchannel_switchstatuscommand.h"
+#include "../gridcreatingconditioncompoundchannelcenterline.h"
+#include "../gridcreatingconditioncompoundchannelgridregionpolygon.h"
+#include "../gridcreatingconditioncompoundchannellowwaterchannelpolygon.h"
+
+#include <guicore/pre/base/preprocessorwindowinterface.h>
+#include <misc/informationdialog.h>
+
+GridCreatingConditionCompoundChannel::SwitchStatusCommand::SwitchStatusCommand(GridCreatingConditionCompoundChannel::Status newStatus, GridCreatingConditionCompoundChannel* condition) :
+	QUndoCommand {GridCreatingConditionCompoundChannel::tr("Finish Defining Polygon or Polygonal line")},
+	m_newStatus {newStatus},
+	m_condition {condition}
+{}
+
+void GridCreatingConditionCompoundChannel::SwitchStatusCommand::redo()
+{
+	m_condition->m_status = m_newStatus;
+	switch (m_newStatus) {
+	case GridCreatingConditionCompoundChannel::stDefiningLowWaterRegion:
+		m_condition->m_mouseEventMode = GridCreatingConditionCompoundChannel::meBeforeDefining;
+		m_condition->m_selectedPolygon = m_condition->m_lowWaterChannelPolygon;
+		m_condition->m_gridRegionPolygon->setActive(false);
+		m_condition->m_lowWaterChannelPolygon->setActive(true);
+		InformationDialog::information(m_condition->preProcessorWindow(), GridCreatingConditionCompoundChannel::tr("Information"), GridCreatingConditionCompoundChannel::tr("Next, please define low water channel region. Water channel can be defined as polygon by mouse-clicking. Finish definining by double clicking, or pressing return key."), "gccompoundchannel_lowwater");
+		break;
+	case GridCreatingConditionCompoundChannel::stDefiningCenterLine:
+		m_condition->m_mouseEventMode = GridCreatingConditionCompoundChannel::meBeforeDefining;
+		m_condition->m_selectedLine = m_condition->m_centerLine;
+		m_condition->m_lowWaterChannelPolygon->setActive(false);
+		m_condition->m_centerLine->setActive(true);
+		InformationDialog::information(m_condition->preProcessorWindow(), GridCreatingConditionCompoundChannel::tr("Information"), GridCreatingConditionCompoundChannel::tr("Next, please define grid center line. Grid center line can be defined as polygonal line by mouse-clicking. Finish definining by double clicking, or pressing return key."), "gccompoundchannel_centerline");
+		break;
+	case GridCreatingConditionCompoundChannel::stNormal:
+		m_condition->m_mouseEventMode = GridCreatingConditionCompoundChannel::meNormal;
+		m_condition->m_selectMode = GridCreatingConditionCompoundChannel::smLine;
+		m_condition->m_selectedLine = m_condition->m_centerLine;
+		m_condition->m_centerLine->setActive(true);
+		m_condition->create(m_condition->preProcessorWindow());
+		break;
+	default:
+		break;
+	}
+	m_condition->updateMouseCursor(m_condition->graphicsView());
+	m_condition->updateActionStatus();
+	m_condition->renderGraphicsView();
+}
+
+void GridCreatingConditionCompoundChannel::SwitchStatusCommand::undo() {
+	switch (m_newStatus) {
+	case GridCreatingConditionCompoundChannel::stDefiningLowWaterRegion:
+		m_condition->m_status = GridCreatingConditionCompoundChannel::stDefiningRegion;
+		m_condition->m_selectedPolygon = m_condition->m_gridRegionPolygon;
+		m_condition->m_gridRegionPolygon->setActive(true);
+		m_condition->m_lowWaterChannelPolygon->setActive(false);
+		break;
+	case GridCreatingConditionCompoundChannel::stDefiningCenterLine:
+		m_condition->m_status = GridCreatingConditionCompoundChannel::stDefiningLowWaterRegion;
+		m_condition->m_selectedPolygon = m_condition->m_lowWaterChannelPolygon;
+		m_condition->m_lowWaterChannelPolygon->setActive(true);
+		m_condition->m_centerLine->setActive(false);
+		break;
+	case GridCreatingConditionCompoundChannel::stNormal:
+		m_condition->m_status = GridCreatingConditionCompoundChannel::stDefiningCenterLine;
+		m_condition->m_selectedLine = m_condition->m_centerLine;
+		m_condition->m_centerLine->setActive(true);
+		break;
+	default:
+		break;
+	}
+	m_condition->m_mouseEventMode = GridCreatingConditionCompoundChannel::meDefining;
+
+	m_condition->updateMouseCursor(m_condition->graphicsView());
+	m_condition->updateActionStatus();
+}

--- a/libs/gridcreatingcondition/compoundchannel/private/gridcreatingconditioncompoundchannel_switchstatuscommand.h
+++ b/libs/gridcreatingcondition/compoundchannel/private/gridcreatingconditioncompoundchannel_switchstatuscommand.h
@@ -1,0 +1,21 @@
+#ifndef GRIDCREATINGCONDITIONCOMPOUNDCHANNEL_SWITCHSTATUSCOMMAND_H
+#define GRIDCREATINGCONDITIONCOMPOUNDCHANNEL_SWITCHSTATUSCOMMAND_H
+
+#include "../gridcreatingconditioncompoundchannel.h"
+
+#include <QUndoCommand>
+
+class GridCreatingConditionCompoundChannel::SwitchStatusCommand : public QUndoCommand
+{
+public:
+	SwitchStatusCommand(GridCreatingConditionCompoundChannel::Status newStatus, GridCreatingConditionCompoundChannel* condition);
+
+	void redo() override;
+	void undo() override;
+
+private:
+	GridCreatingConditionCompoundChannel::Status m_newStatus;
+	GridCreatingConditionCompoundChannel* m_condition;
+};
+
+#endif // GRIDCREATINGCONDITIONCOMPOUNDCHANNEL_SWITCHSTATUSCOMMAND_H


### PR DESCRIPTION
Compound channel grid generator code is made clean by:

* Separating QUndoCommand subclasses from gridcreatingconditioncompoundchannel.cpp
* function implementation moved from header file to source file.
* protected -> private
* `QPoint(event->x(), event->y())` -> `event->pos()`
