### PR TITLE
Closes #455, #478, #526

### DIFF
--- a/libs/dataitem/distancemeasure/distancemeasure.pro
+++ b/libs/dataitem/distancemeasure/distancemeasure.pro
@@ -73,9 +73,9 @@ win32 {
 
 # Input
 HEADERS += distancemeasure_api.h \
-           distancemeasurecopypropertydialog.h \
            distancemeasuredataitem.h \
            distancemeasuregroupdataitem.h \
+           distancemeasurepropertydialog.h \
            distancemeasuresetting.h \
            private/distancemeasuredataitem_definecommand.h \
            private/distancemeasuredataitem_impl.h \
@@ -84,10 +84,11 @@ HEADERS += distancemeasure_api.h \
            private/distancemeasuredataitem_setsettingcommand.h \
            private/distancemeasuredataitem_translatecommand.h \
            private/distancemeasuregroupdataitem_impl.h
-FORMS += distancemeasurecopypropertydialog.ui
-SOURCES += distancemeasurecopypropertydialog.cpp \
+FORMS += distancemeasurepropertydialog.ui
+SOURCES += \
            distancemeasuredataitem.cpp \
            distancemeasuregroupdataitem.cpp \
+           distancemeasurepropertydialog.cpp \
            distancemeasuresetting.cpp \
            private/distancemeasuredataitem_definecommand.cpp \
            private/distancemeasuredataitem_movevertexcommand.cpp \

--- a/libs/dataitem/distancemeasure/distancemeasuredataitem.cpp
+++ b/libs/dataitem/distancemeasure/distancemeasuredataitem.cpp
@@ -1,4 +1,5 @@
 #include "distancemeasuredataitem.h"
+#include "distancemeasurepropertydialog.h"
 #include "private/distancemeasuredataitem_definecommand.h"
 #include "private/distancemeasuredataitem_impl.h"
 #include "private/distancemeasuredataitem_movevertexcommand.h"
@@ -267,7 +268,7 @@ void DistanceMeasureDataItem::updateActorSettings()
 	impl->m_labelActor.setLabelPosition(impl->m_setting.labelPosition);
 
 	vtkTextProperty* txtProp = impl->m_labelActor.labelTextProperty();
-	txtProp->SetFontSize(impl->m_setting.labelFontSize);
+	impl->m_setting.labelFontSetting.applySetting(txtProp);
 	txtProp->SetColor(impl->m_setting.color);
 
 	impl->m_lineActor.pointsActor()->GetProperty()->SetColor(impl->m_setting.color);

--- a/libs/dataitem/distancemeasure/distancemeasuredataitem.cpp
+++ b/libs/dataitem/distancemeasure/distancemeasuredataitem.cpp
@@ -305,7 +305,7 @@ QDialog* DistanceMeasureDataItem::propertyDialog(QWidget* parent)
 	v1 = QVector2D(line.at(0).x(), line.at(0).y());
 	v2 = QVector2D(line.at(1).x(), line.at(1).y());
 
-	DistanceMeasureCopyPropertyDialog* dialog = new DistanceMeasureCopyPropertyDialog(parent);
+	auto dialog = new DistanceMeasurePropertyDialog(parent);
 	dialog->setName(m_standardItem->text().trimmed());
 	dialog->setSetting(impl->m_setting);
 
@@ -314,7 +314,7 @@ QDialog* DistanceMeasureDataItem::propertyDialog(QWidget* parent)
 
 void DistanceMeasureDataItem::handlePropertyDialogAccepted(QDialog* propDialog)
 {
-	DistanceMeasureCopyPropertyDialog* dialog = dynamic_cast<DistanceMeasureCopyPropertyDialog*>(propDialog);
+	auto dialog = dynamic_cast<DistanceMeasurePropertyDialog*>(propDialog);
 	iRICUndoStack::instance().push(new SetSettingCommand(dialog->name(), dialog->setting(), this));
 }
 

--- a/libs/dataitem/distancemeasure/distancemeasuredataitem.h
+++ b/libs/dataitem/distancemeasure/distancemeasuredataitem.h
@@ -3,7 +3,6 @@
 
 #include "distancemeasure_api.h"
 #include "distancemeasuresetting.h"
-#include "distancemeasurecopypropertydialog.h"
 
 #include <guicore/datamodel/graphicswindowdataitem.h>
 

--- a/libs/dataitem/distancemeasure/distancemeasurepropertydialog.cpp
+++ b/libs/dataitem/distancemeasure/distancemeasurepropertydialog.cpp
@@ -9,6 +9,8 @@ DistanceMeasurePropertyDialog::DistanceMeasurePropertyDialog(QWidget* parent) :
 	ui {new Ui::DistanceMeasurePropertyDialog}
 {
 	ui->setupUi(this);
+	ui->labelFontSettingWidget->hideColor();
+
 	connect(ui->startPointXEdit, SIGNAL(valueChanged(double)), this, SLOT(updateAutoLabel()));
 	connect(ui->startPointYEdit, SIGNAL(valueChanged(double)), this, SLOT(updateAutoLabel()));
 	connect(ui->endPointXEdit, SIGNAL(valueChanged(double)), this, SLOT(updateAutoLabel()));
@@ -55,13 +57,14 @@ DistanceMeasureSetting DistanceMeasurePropertyDialog::setting() const
 		ret.labelPosition = vtkLabel2DActor::lpMiddleRight;
 	}
 
-	ret.labelFontSize = ui->fontSizeSpinBox->value();
+	ret.labelFontSetting = ui->labelFontSettingWidget->setting();
 	ret.customLabel = ui->customLabelLineEdit->text();
 
 	ret.showMarkers = ui->showMarkersCheckBox->isChecked();
 	ret.markerSize = ui->markerSizeSpinBox->value();
 
 	ret.color = ui->colorWidget->color();
+	ret.labelFontSetting.fontColor = ret.color;
 
 	return ret;
 }
@@ -100,7 +103,7 @@ void DistanceMeasurePropertyDialog::setSetting(const DistanceMeasureSetting& set
 		ui->lpCenterTop->setChecked(true);
 	}
 
-	ui->fontSizeSpinBox->setValue(setting.labelFontSize);
+	ui->labelFontSettingWidget->setSetting(setting.labelFontSetting);
 	ui->customLabelLineEdit->setText(setting.customLabel);
 
 	ui->showMarkersCheckBox->setChecked(setting.showMarkers);

--- a/libs/dataitem/distancemeasure/distancemeasurepropertydialog.cpp
+++ b/libs/dataitem/distancemeasure/distancemeasurepropertydialog.cpp
@@ -1,12 +1,12 @@
-#include "ui_distancemeasurecopypropertydialog.h"
+#include "ui_distancemeasurepropertydialog.h"
 
-#include "distancemeasurecopypropertydialog.h"
+#include "distancemeasurepropertydialog.h"
 
 #include <QVector2D>
 
-DistanceMeasureCopyPropertyDialog::DistanceMeasureCopyPropertyDialog(QWidget* parent) :
+DistanceMeasurePropertyDialog::DistanceMeasurePropertyDialog(QWidget* parent) :
 	QDialog {parent},
-	ui {new Ui::DistanceMeasureCopyPropertyDialog}
+	ui {new Ui::DistanceMeasurePropertyDialog}
 {
 	ui->setupUi(this);
 	connect(ui->startPointXEdit, SIGNAL(valueChanged(double)), this, SLOT(updateAutoLabel()));
@@ -15,22 +15,22 @@ DistanceMeasureCopyPropertyDialog::DistanceMeasureCopyPropertyDialog(QWidget* pa
 	connect(ui->endPointYEdit, SIGNAL(valueChanged(double)), this, SLOT(updateAutoLabel()));
 }
 
-DistanceMeasureCopyPropertyDialog::~DistanceMeasureCopyPropertyDialog()
+DistanceMeasurePropertyDialog::~DistanceMeasurePropertyDialog()
 {
 	delete ui;
 }
 
-QString DistanceMeasureCopyPropertyDialog::name() const
+QString DistanceMeasurePropertyDialog::name() const
 {
 	return ui->nameLineEdit->text();
 }
 
-void DistanceMeasureCopyPropertyDialog::setName(const QString& name)
+void DistanceMeasurePropertyDialog::setName(const QString& name)
 {
 	ui->nameLineEdit->setText(name.trimmed());
 }
 
-DistanceMeasureSetting DistanceMeasureCopyPropertyDialog::setting() const
+DistanceMeasureSetting DistanceMeasurePropertyDialog::setting() const
 {
 	DistanceMeasureSetting ret = m_setting;
 
@@ -66,7 +66,7 @@ DistanceMeasureSetting DistanceMeasureCopyPropertyDialog::setting() const
 	return ret;
 }
 
-void DistanceMeasureCopyPropertyDialog::setSetting(const DistanceMeasureSetting& setting)
+void DistanceMeasurePropertyDialog::setSetting(const DistanceMeasureSetting& setting)
 {
 	m_setting = setting;
 
@@ -109,12 +109,12 @@ void DistanceMeasureCopyPropertyDialog::setSetting(const DistanceMeasureSetting&
 	ui->colorWidget->setColor(setting.color);
 }
 
-void DistanceMeasureCopyPropertyDialog::updateAutoLabel()
+void DistanceMeasurePropertyDialog::updateAutoLabel()
 {
 	ui->autoLabelLabel->setText(autoLabel());
 }
 
-QString DistanceMeasureCopyPropertyDialog::autoLabel() const
+QString DistanceMeasurePropertyDialog::autoLabel() const
 {
 	QVector2D v1(ui->startPointXEdit->value(), ui->startPointYEdit->value());
 	QVector2D v2(ui->endPointXEdit->value(), ui->endPointYEdit->value());

--- a/libs/dataitem/distancemeasure/distancemeasurepropertydialog.h
+++ b/libs/dataitem/distancemeasure/distancemeasurepropertydialog.h
@@ -1,5 +1,5 @@
-#ifndef DISTANCEMEASURECOPYPROPERTYDIALOG_H
-#define DISTANCEMEASURECOPYPROPERTYDIALOG_H
+#ifndef DISTANCEMEASUREPROPERTYDIALOG_H
+#define DISTANCEMEASUREPROPERTYDIALOG_H
 
 #include "distancemeasure_api.h"
 #include "distancemeasuresetting.h"
@@ -10,17 +10,17 @@ class QVector2D;
 
 namespace Ui
 {
-	class DistanceMeasureCopyPropertyDialog;
+	class DistanceMeasurePropertyDialog;
 }
 
-class DISTANCEMEASURE_API DistanceMeasureCopyPropertyDialog : public QDialog
+class DISTANCEMEASURE_API DistanceMeasurePropertyDialog : public QDialog
 {
 	Q_OBJECT
 
 public:
 
-	explicit DistanceMeasureCopyPropertyDialog(QWidget* parent = nullptr);
-	~DistanceMeasureCopyPropertyDialog();
+	explicit DistanceMeasurePropertyDialog(QWidget* parent = nullptr);
+	~DistanceMeasurePropertyDialog();
 
 	QString name() const;
 	void setName(const QString& name);
@@ -35,7 +35,7 @@ private:
 	QString autoLabel() const;
 
 	DistanceMeasureSetting m_setting;
-	Ui::DistanceMeasureCopyPropertyDialog* ui;
+	Ui::DistanceMeasurePropertyDialog* ui;
 };
 
-#endif // DISTANCEMEASURECOPYPROPERTYDIALOG_H
+#endif // DISTANCEMEASUREPROPERTYDIALOG_H

--- a/libs/dataitem/distancemeasure/distancemeasurepropertydialog.ui
+++ b/libs/dataitem/distancemeasure/distancemeasurepropertydialog.ui
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
- <class>DistanceMeasureCopyPropertyDialog</class>
- <widget class="QDialog" name="DistanceMeasureCopyPropertyDialog">
+ <class>DistanceMeasurePropertyDialog</class>
+ <widget class="QDialog" name="DistanceMeasurePropertyDialog">
   <property name="geometry">
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>349</width>
-    <height>469</height>
+    <width>361</width>
+    <height>489</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -77,7 +77,7 @@
      <property name="title">
       <string>Label</string>
      </property>
-     <layout class="QVBoxLayout" name="verticalLayout">
+     <layout class="QVBoxLayout" name="verticalLayout_2">
       <item>
        <widget class="QCheckBox" name="showLabelCheckBox">
         <property name="text">
@@ -179,38 +179,16 @@
        </layout>
       </item>
       <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_4">
-        <item>
-         <widget class="QLabel" name="fontSizeLabel">
-          <property name="text">
-           <string>Font Size:</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QSpinBox" name="fontSizeSpinBox">
-          <property name="minimum">
-           <number>6</number>
-          </property>
-          <property name="maximum">
-           <number>40</number>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <spacer name="horizontalSpacer_4">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-       </layout>
+       <widget class="QGroupBox" name="groupBox_4">
+        <property name="title">
+         <string>Font Setting</string>
+        </property>
+        <layout class="QVBoxLayout" name="verticalLayout">
+         <item>
+          <widget class="vtkTextPropertySettingWidget" name="fontSettingWidget" native="true"/>
+         </item>
+        </layout>
+       </widget>
       </item>
      </layout>
     </widget>
@@ -333,14 +311,21 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>RealNumberEditWidget</class>
-   <extends>QLineEdit</extends>
-   <header>guibase/widget/realnumbereditwidget.h</header>
-  </customwidget>
-  <customwidget>
    <class>ColorEditWidget</class>
    <extends>QLabel</extends>
    <header>guibase/widget/coloreditwidget.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>RealNumberEditWidget</class>
+   <extends>QLineEdit</extends>
+   <header>widget/realnumbereditwidget.h</header>
+  </customwidget>
+  <customwidget>
+   <class>vtkTextPropertySettingWidget</class>
+   <extends>QWidget</extends>
+   <header>guibase/vtktextpropertysettingwidget.h</header>
+   <container>1</container>
   </customwidget>
  </customwidgets>
  <resources/>
@@ -348,7 +333,7 @@
   <connection>
    <sender>buttonBox</sender>
    <signal>accepted()</signal>
-   <receiver>DistanceMeasureCopyPropertyDialog</receiver>
+   <receiver>DistanceMeasurePropertyDialog</receiver>
    <slot>accept()</slot>
    <hints>
     <hint type="sourcelabel">
@@ -364,7 +349,7 @@
   <connection>
    <sender>buttonBox</sender>
    <signal>rejected()</signal>
-   <receiver>DistanceMeasureCopyPropertyDialog</receiver>
+   <receiver>DistanceMeasurePropertyDialog</receiver>
    <slot>reject()</slot>
    <hints>
     <hint type="sourcelabel">

--- a/libs/dataitem/distancemeasure/distancemeasurepropertydialog.ui
+++ b/libs/dataitem/distancemeasure/distancemeasurepropertydialog.ui
@@ -185,7 +185,7 @@
         </property>
         <layout class="QVBoxLayout" name="verticalLayout">
          <item>
-          <widget class="vtkTextPropertySettingWidget" name="fontSettingWidget" native="true"/>
+          <widget class="vtkTextPropertySettingWidget" name="labelFontSettingWidget" native="true"/>
          </item>
         </layout>
        </widget>
@@ -319,7 +319,7 @@
   <customwidget>
    <class>RealNumberEditWidget</class>
    <extends>QLineEdit</extends>
-   <header>widget/realnumbereditwidget.h</header>
+   <header>guibase/widget/realnumbereditwidget.h</header>
   </customwidget>
   <customwidget>
    <class>vtkTextPropertySettingWidget</class>

--- a/libs/dataitem/distancemeasure/distancemeasuresetting.cpp
+++ b/libs/dataitem/distancemeasure/distancemeasuresetting.cpp
@@ -4,7 +4,7 @@
 
 DistanceMeasureSetting::DistanceMeasureSetting() :
 	CompositeContainer({&defined, &point1, &point2,
-		&showLabel, &labelMode, &labelPosition, &labelFontSize, &customLabel,
+		&showLabel, &labelMode, &labelPosition, &labelFontSetting, &customLabel,
 		&showMarkers, &markerSize, &color}),
 	defined {"defined", false},
 	point1 {"point1"},
@@ -12,12 +12,14 @@ DistanceMeasureSetting::DistanceMeasureSetting() :
 	showLabel {"showLabel", true},
 	labelMode {"labelMode", Auto},
 	labelPosition {"labelPosition", vtkLabel2DActor::lpTopCenter},
-	labelFontSize {"fontSize", 12},
+	labelFontSetting {},
 	customLabel {"customLabel"},
 	showMarkers {"showMarkers", true},
 	markerSize {"markerSize", 7},
 	color {"color", Qt::black}
-{}
+{
+	labelFontSetting.fontSize = 12;
+}
 
 DistanceMeasureSetting::DistanceMeasureSetting(const DistanceMeasureSetting& setting) :
 	DistanceMeasureSetting {}

--- a/libs/dataitem/distancemeasure/distancemeasuresetting.h
+++ b/libs/dataitem/distancemeasure/distancemeasuresetting.h
@@ -2,7 +2,7 @@
 #define DISTANCEMEASURESETTING_H
 
 #include <guibase/vtktool/vtklabel2dactor.h>
-
+#include <guibase/vtktextpropertysettingcontainer.h>
 #include <misc/boolcontainer.h>
 #include <misc/colorcontainer.h>
 #include <misc/compositecontainer.h>
@@ -34,7 +34,7 @@ public:
 	BoolContainer showLabel;
 	EnumContainerT<LabelMode> labelMode;
 	EnumContainerT<vtkLabel2DActor::LabelPosition> labelPosition;
-	IntContainer labelFontSize;
+	vtkTextPropertySettingContainer labelFontSetting;
 	StringContainer customLabel;
 
 	BoolContainer showMarkers;

--- a/libs/dataitem/distancemeasure/private/distancemeasuredataitem_impl.h
+++ b/libs/dataitem/distancemeasure/private/distancemeasuredataitem_impl.h
@@ -6,6 +6,11 @@
 #include <guibase/vtktool/vtklabel2dactor.h>
 #include <guibase/vtktool/vtklineactor.h>
 
+#include <QCursor>
+#include <QPixmap>
+
+class QAction;
+
 class DistanceMeasureDataItem::Impl
 {
 public:

--- a/libs/guibase/guibase.pro
+++ b/libs/guibase/guibase.pro
@@ -104,6 +104,7 @@ HEADERS += arrowsettingcontainer.h \
            vtksubdividegrid.h \
            vtktextpropertysettingcontainer.h \
            vtktextpropertysettingdialog.h \
+           vtktextpropertysettingwidget.h \
            xyaxisdisplaysettingdialog.h \
            colormap/colormapcustomsetting.h \
            colormap/colormapcustomsettingcolor.h \
@@ -170,6 +171,7 @@ FORMS += scalarbardialog.ui \
          structuredgridregionselectwidget.ui \
          vtklinestylewidget.ui \
          vtktextpropertysettingdialog.ui \
+         vtktextpropertysettingwidget.ui \
          xyaxisdisplaysettingdialog.ui \
          colormap/colormapcustomsettingdialog.ui \
          colormap/colormapsettingwidget.ui \
@@ -217,6 +219,7 @@ SOURCES += arrowsettingcontainer.cpp \
            vtksubdividegrid.cpp \
            vtktextpropertysettingcontainer.cpp \
            vtktextpropertysettingdialog.cpp \
+           vtktextpropertysettingwidget.cpp \
            xyaxisdisplaysettingdialog.cpp \
            colormap/colormapcustomsetting.cpp \
            colormap/colormapcustomsettingcolor.cpp \

--- a/libs/guibase/vtktextpropertysettingdialog.cpp
+++ b/libs/guibase/vtktextpropertysettingdialog.cpp
@@ -17,36 +17,20 @@ vtkTextPropertySettingDialog::~vtkTextPropertySettingDialog()
 
 vtkTextPropertySettingContainer vtkTextPropertySettingDialog::setting() const
 {
-	vtkTextPropertySettingContainer c;
-	c.setPrefix(m_prefix);
-	c.fontFamily = static_cast<vtkTextPropertySettingContainer::FontFamily>(ui->fontComboBox->currentIndex());
-	c.fontSize = ui->sizeSpinBox->value();
-	c.fontColor = ui->colorWidget->color();
-	c.isBold = ui->boldButton->isChecked();
-	c.isItalic = ui->italicButton->isChecked();
-	c.isShadow = ui->shadowButton->isChecked();
-	return c;
+	return ui->widget->setting();
 }
 
 void vtkTextPropertySettingDialog::setSetting(const vtkTextPropertySettingContainer& setting)
 {
-	m_prefix = setting.prefix();
-	ui->fontComboBox->setCurrentIndex(static_cast<int>(setting.fontFamily));
-	ui->sizeSpinBox->setValue(setting.fontSize);
-	ui->colorWidget->setColor(setting.fontColor);
-	ui->boldButton->setChecked(setting.isBold);
-	ui->italicButton->setChecked(setting.isItalic);
-	ui->shadowButton->setChecked(setting.isShadow);
+	ui->widget->setSetting(setting);
 }
 
 void vtkTextPropertySettingDialog::disableSize()
 {
-	ui->sizeSpinBox->clear();
-	ui->sizeSpinBox->setDisabled(true);
+	ui->widget->disableSize();
 }
 
 void vtkTextPropertySettingDialog::disableColor()
 {
-	ui->colorWidget->setColor(QColor(Qt::gray));
-	ui->colorWidget->setDisabled(true);
+	ui->widget->disableColor();
 }

--- a/libs/guibase/vtktextpropertysettingdialog.ui
+++ b/libs/guibase/vtktextpropertysettingdialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>264</width>
-    <height>136</height>
+    <width>249</width>
+    <height>65</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -15,203 +15,7 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <layout class="QGridLayout" name="gridLayout">
-     <item row="0" column="0">
-      <widget class="QLabel" name="fontLabel">
-       <property name="text">
-        <string>Font:</string>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="1">
-      <layout class="QHBoxLayout" name="horizontalLayout_3">
-       <item>
-        <widget class="QComboBox" name="fontComboBox">
-         <item>
-          <property name="text">
-           <string>Arial</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>Courier</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>Times</string>
-          </property>
-         </item>
-        </widget>
-       </item>
-       <item>
-        <widget class="QPushButton" name="boldButton">
-         <property name="maximumSize">
-          <size>
-           <width>40</width>
-           <height>16777215</height>
-          </size>
-         </property>
-         <property name="font">
-          <font>
-           <weight>75</weight>
-           <bold>true</bold>
-          </font>
-         </property>
-         <property name="toolTip">
-          <string>Bold</string>
-         </property>
-         <property name="text">
-          <string>B</string>
-         </property>
-         <property name="checkable">
-          <bool>true</bool>
-         </property>
-         <property name="checked">
-          <bool>false</bool>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QPushButton" name="italicButton">
-         <property name="maximumSize">
-          <size>
-           <width>40</width>
-           <height>16777215</height>
-          </size>
-         </property>
-         <property name="font">
-          <font>
-           <weight>50</weight>
-           <italic>true</italic>
-           <bold>false</bold>
-          </font>
-         </property>
-         <property name="toolTip">
-          <string>Italic</string>
-         </property>
-         <property name="text">
-          <string>I</string>
-         </property>
-         <property name="checkable">
-          <bool>true</bool>
-         </property>
-         <property name="checked">
-          <bool>false</bool>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QPushButton" name="shadowButton">
-         <property name="maximumSize">
-          <size>
-           <width>40</width>
-           <height>16777215</height>
-          </size>
-         </property>
-         <property name="font">
-          <font>
-           <weight>50</weight>
-           <italic>false</italic>
-           <bold>false</bold>
-           <underline>true</underline>
-          </font>
-         </property>
-         <property name="toolTip">
-          <string>Shadow</string>
-         </property>
-         <property name="text">
-          <string>S</string>
-         </property>
-         <property name="checkable">
-          <bool>true</bool>
-         </property>
-         <property name="checked">
-          <bool>false</bool>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <spacer name="horizontalSpacer_3">
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>40</width>
-           <height>20</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-      </layout>
-     </item>
-     <item row="1" column="0">
-      <widget class="QLabel" name="colorLabel">
-       <property name="text">
-        <string>Color:</string>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="1">
-      <layout class="QHBoxLayout" name="horizontalLayout_2">
-       <item>
-        <widget class="ColorEditWidget" name="colorWidget">
-         <property name="frameShape">
-          <enum>QFrame::Panel</enum>
-         </property>
-         <property name="text">
-          <string/>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <spacer name="horizontalSpacer_2">
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>40</width>
-           <height>20</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-      </layout>
-     </item>
-     <item row="2" column="0">
-      <widget class="QLabel" name="sizeLabel">
-       <property name="text">
-        <string>Size:</string>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="1">
-      <layout class="QHBoxLayout" name="horizontalLayout">
-       <item>
-        <widget class="QSpinBox" name="sizeSpinBox">
-         <property name="minimum">
-          <number>5</number>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <spacer name="horizontalSpacer">
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>40</width>
-           <height>20</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-      </layout>
-     </item>
-    </layout>
+    <widget class="vtkTextPropertySettingWidget" name="widget" native="true"/>
    </item>
    <item>
     <spacer name="verticalSpacer">
@@ -240,9 +44,9 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>ColorEditWidget</class>
-   <extends>QLabel</extends>
-   <header>guibase/widget/coloreditwidget.h</header>
+   <class>vtkTextPropertySettingWidget</class>
+   <extends>QWidget</extends>
+   <header>guibase/vtktextpropertysettingwidget.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>

--- a/libs/guibase/vtktextpropertysettingwidget.cpp
+++ b/libs/guibase/vtktextpropertysettingwidget.cpp
@@ -1,0 +1,59 @@
+#include "ui_vtktextpropertysettingwidget.h"
+
+#include "vtktextpropertysettingcontainer.h"
+#include "vtktextpropertysettingwidget.h"
+
+vtkTextPropertySettingWidget::vtkTextPropertySettingWidget(QWidget* parent) :
+	QWidget(parent),
+	ui(new Ui::vtkTextPropertySettingWidget)
+{
+	ui->setupUi(this);
+}
+
+vtkTextPropertySettingWidget::~vtkTextPropertySettingWidget()
+{
+	delete ui;
+}
+
+vtkTextPropertySettingContainer vtkTextPropertySettingWidget::setting() const
+{
+	vtkTextPropertySettingContainer c;
+	c.setPrefix(m_prefix);
+	c.fontFamily = static_cast<vtkTextPropertySettingContainer::FontFamily>(ui->fontComboBox->currentIndex());
+	c.fontSize = ui->sizeSpinBox->value();
+	c.fontColor = ui->colorWidget->color();
+	c.isBold = ui->boldButton->isChecked();
+	c.isItalic = ui->italicButton->isChecked();
+	c.isShadow = ui->shadowButton->isChecked();
+	return c;
+}
+
+void vtkTextPropertySettingWidget::setSetting(const vtkTextPropertySettingContainer& setting)
+{
+	m_prefix = setting.prefix();
+	ui->fontComboBox->setCurrentIndex(static_cast<int>(setting.fontFamily));
+	ui->sizeSpinBox->setValue(setting.fontSize);
+	ui->colorWidget->setColor(setting.fontColor);
+	ui->boldButton->setChecked(setting.isBold);
+	ui->italicButton->setChecked(setting.isItalic);
+	ui->shadowButton->setChecked(setting.isShadow);
+}
+
+void vtkTextPropertySettingWidget::disableSize()
+{
+	ui->sizeSpinBox->clear();
+	ui->sizeSpinBox->setDisabled(true);
+}
+
+void vtkTextPropertySettingWidget::disableColor()
+{
+	ui->colorWidget->setColor(QColor(Qt::gray));
+	ui->colorWidget->setDisabled(true);
+}
+
+void vtkTextPropertySettingWidget::hideColor()
+{
+	ui->colorLabel->hide();
+	ui->colorWidget->hide();
+	updateGeometry();
+}

--- a/libs/guibase/vtktextpropertysettingwidget.h
+++ b/libs/guibase/vtktextpropertysettingwidget.h
@@ -1,0 +1,39 @@
+#ifndef VTKTEXTPROPERTYSETTINGWIDGET_H
+#define VTKTEXTPROPERTYSETTINGWIDGET_H
+
+#include "guibase_global.h"
+
+#include <QString>
+#include <QWidget>
+
+class vtkTextPropertySettingContainer;
+
+namespace Ui {
+class vtkTextPropertySettingWidget;
+}
+
+class GUIBASEDLL_EXPORT vtkTextPropertySettingWidget : public QWidget
+{
+	Q_OBJECT
+
+public:
+	explicit vtkTextPropertySettingWidget(QWidget *parent = nullptr);
+	~vtkTextPropertySettingWidget();
+	/// The setting
+	vtkTextPropertySettingContainer setting() const;
+	/// Set the setting
+	void setSetting(const vtkTextPropertySettingContainer& setting);
+
+	/// Disable the widget to edit font size
+	void disableSize();
+	/// Disable the widget to edit font color
+	void disableColor();
+	/// Hide the widget to edit font color
+	void hideColor();
+
+private:
+	QString m_prefix;
+	Ui::vtkTextPropertySettingWidget *ui;
+};
+
+#endif // VTKTEXTPROPERTYSETTINGWIDGET_H

--- a/libs/guibase/vtktextpropertysettingwidget.ui
+++ b/libs/guibase/vtktextpropertysettingwidget.ui
@@ -1,0 +1,282 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>vtkTextPropertySettingWidget</class>
+ <widget class="QWidget" name="vtkTextPropertySettingWidget">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>347</width>
+    <height>138</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="spacing">
+    <number>0</number>
+   </property>
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_4">
+     <property name="spacing">
+      <number>0</number>
+     </property>
+     <property name="rightMargin">
+      <number>0</number>
+     </property>
+     <item>
+      <layout class="QGridLayout" name="gridLayout">
+       <property name="spacing">
+        <number>6</number>
+       </property>
+       <item row="0" column="0">
+        <widget class="QLabel" name="fontLabel">
+         <property name="text">
+          <string>Font:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="1">
+        <layout class="QHBoxLayout" name="horizontalLayout_3">
+         <item>
+          <widget class="QComboBox" name="fontComboBox">
+           <item>
+            <property name="text">
+             <string>Arial</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>Courier</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>Times</string>
+            </property>
+           </item>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="boldButton">
+           <property name="maximumSize">
+            <size>
+             <width>40</width>
+             <height>16777215</height>
+            </size>
+           </property>
+           <property name="font">
+            <font>
+             <weight>75</weight>
+             <bold>true</bold>
+            </font>
+           </property>
+           <property name="toolTip">
+            <string>Bold</string>
+           </property>
+           <property name="text">
+            <string>B</string>
+           </property>
+           <property name="checkable">
+            <bool>true</bool>
+           </property>
+           <property name="checked">
+            <bool>false</bool>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="italicButton">
+           <property name="maximumSize">
+            <size>
+             <width>40</width>
+             <height>16777215</height>
+            </size>
+           </property>
+           <property name="font">
+            <font>
+             <weight>50</weight>
+             <italic>true</italic>
+             <bold>false</bold>
+            </font>
+           </property>
+           <property name="toolTip">
+            <string>Italic</string>
+           </property>
+           <property name="text">
+            <string>I</string>
+           </property>
+           <property name="checkable">
+            <bool>true</bool>
+           </property>
+           <property name="checked">
+            <bool>false</bool>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="shadowButton">
+           <property name="maximumSize">
+            <size>
+             <width>40</width>
+             <height>16777215</height>
+            </size>
+           </property>
+           <property name="font">
+            <font>
+             <weight>50</weight>
+             <italic>false</italic>
+             <bold>false</bold>
+             <underline>true</underline>
+            </font>
+           </property>
+           <property name="toolTip">
+            <string>Shadow</string>
+           </property>
+           <property name="text">
+            <string>S</string>
+           </property>
+           <property name="checkable">
+            <bool>true</bool>
+           </property>
+           <property name="checked">
+            <bool>false</bool>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer_3">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+        </layout>
+       </item>
+       <item row="1" column="0">
+        <widget class="QLabel" name="colorLabel">
+         <property name="text">
+          <string>Color:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="1">
+        <layout class="QHBoxLayout" name="horizontalLayout_2">
+         <item>
+          <widget class="ColorEditWidget" name="colorWidget">
+           <property name="frameShape">
+            <enum>QFrame::Panel</enum>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer_2">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>0</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+        </layout>
+       </item>
+       <item row="2" column="0">
+        <widget class="QLabel" name="sizeLabel">
+         <property name="text">
+          <string>Size:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="1">
+        <layout class="QHBoxLayout" name="horizontalLayout">
+         <item>
+          <widget class="QSpinBox" name="sizeSpinBox">
+           <property name="minimum">
+            <number>5</number>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+        </layout>
+       </item>
+      </layout>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer_4">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>5</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>ColorEditWidget</class>
+   <extends>QLabel</extends>
+   <header>guibase/widget/coloreditwidget.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/libs/postbase/time/posttimedataitem.cpp
+++ b/libs/postbase/time/posttimedataitem.cpp
@@ -14,10 +14,12 @@
 #include <vtkTextProperty.h>
 
 PostTimeDataItem::Setting::Setting() :
-	CompositeContainer ({&timeFormat, &color}),
+	CompositeContainer ({&timeFormat, &fontSetting}),
 	timeFormat {"format", TimeFormat::Format::Second},
-	color {"color", Qt::black}
-{}
+	fontSetting {}
+{
+	fontSetting.fontSize = FONTSIZE;
+}
 
 PostTimeDataItem::Setting::Setting(const Setting& s) :
 	Setting()
@@ -98,9 +100,7 @@ void PostTimeDataItem::updateActorSettings()
 	m_timeActor->SetPosition(0.4, 0.05);
 
 	vtkTextProperty* prop = m_timeActor->GetTextProperty();
-	prop->SetColor(m_setting.color);
-	prop->SetFontFamilyToArial();
-	prop->SetFontSize(FONTSIZE);
+	m_setting.fontSetting.applySetting(prop);
 	prop->SetJustificationToLeft();
 	prop->SetVerticalJustificationToBottom();
 }

--- a/libs/postbase/time/posttimedataitem.h
+++ b/libs/postbase/time/posttimedataitem.h
@@ -3,6 +3,7 @@
 
 #include "../postbase_global.h"
 
+#include <guibase/vtktextpropertysettingcontainer.h>
 #include <guicore/datamodel/graphicswindowdataitem.h>
 #include <misc/timeformat.h>
 #include <misc/compositecontainer.h>
@@ -28,8 +29,8 @@ public:
 
 		/// Time format
 		EnumContainerT<TimeFormat::Format> timeFormat;
-		/// Color
-		ColorContainer color;
+		/// Font setting
+		vtkTextPropertySettingContainer fontSetting;
 	};
 
 	/// Constructor

--- a/libs/postbase/time/posttimeeditdialog.cpp
+++ b/libs/postbase/time/posttimeeditdialog.cpp
@@ -30,7 +30,7 @@ void PostTimeEditDialog::setSetting(const PostTimeDataItem::Setting& setting)
 		ui->dayHourMinuteSecondRadioButton->setChecked(true);
 		break;
 	}
-	ui->colorWidget->setColor(setting.color);
+	ui->fontSettingWidget->setSetting(setting.fontSetting);
 }
 
 PostTimeDataItem::Setting PostTimeEditDialog::setting() const
@@ -45,6 +45,6 @@ PostTimeDataItem::Setting PostTimeEditDialog::setting() const
 	} else {
 		ret.timeFormat = TimeFormat::Format::DayHourMinuteSecond;
 	}
-	ret.color = ui->colorWidget->color();
+	ret.fontSetting = ui->fontSettingWidget->setting();
 	return ret;
 }

--- a/libs/postbase/time/posttimeeditdialog.ui
+++ b/libs/postbase/time/posttimeeditdialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>177</width>
-    <height>195</height>
+    <width>318</width>
+    <height>196</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -52,35 +52,7 @@
     </widget>
    </item>
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout">
-     <item>
-      <widget class="QLabel" name="colorLabel">
-       <property name="text">
-        <string>Color:</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="ColorEditWidget" name="colorWidget">
-       <property name="text">
-        <string/>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <spacer name="horizontalSpacer_3">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-    </layout>
+    <widget class="vtkTextPropertySettingWidget" name="fontSettingWidget" native="true"/>
    </item>
    <item>
     <spacer name="verticalSpacer">
@@ -109,9 +81,9 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>ColorEditWidget</class>
-   <extends>QLabel</extends>
-   <header>guibase/widget/coloreditwidget.h</header>
+   <class>vtkTextPropertySettingWidget</class>
+   <extends>QWidget</extends>
+   <header>guibase/vtktextpropertysettingwidget.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>

--- a/libs/postbase/title/posttitledataitem.cpp
+++ b/libs/postbase/title/posttitledataitem.cpp
@@ -75,11 +75,7 @@ void PostTitleDataItem::updateActorSettings()
 	m_titleActor->SetPosition(0.5, 0.99);
 
 	vtkTextProperty* prop = m_titleActor->GetTextProperty();
-	double c[3];
-	iRIC::QColorToVTKColor(m_setting.color, c);
-	prop->SetColor(c);
-	prop->SetFontFamilyToArial();
-	prop->SetFontSize(m_setting.fontSize);
+	m_setting.fontSetting.applySetting(prop);
 	prop->SetJustificationToCentered();
 	prop->SetVerticalJustificationToTop();
 	updateVisibilityWithoutRendering();

--- a/libs/postbase/title/posttitleeditdialog.cpp
+++ b/libs/postbase/title/posttitleeditdialog.cpp
@@ -27,15 +27,13 @@ bool PostTitleEditDialog::isEnabled() const
 void PostTitleEditDialog::setSetting(const PostTitleSetting& setting)
 {
 	ui->titleLineEdit->setText(setting.title);
-	ui->fontSizeSpinBox->setValue(setting.fontSize);
-	ui->colorWidget->setColor(setting.color);
+	ui->fontSettingWidget->setSetting(setting.fontSetting);
 }
 
 const PostTitleSetting PostTitleEditDialog::setting()
 {
 	PostTitleSetting ret;
 	ret.title = ui->titleLineEdit->text().trimmed();
-	ret.fontSize = ui->fontSizeSpinBox->value();
-	ret.color = ui->colorWidget->color();
+	ret.fontSetting = ui->fontSettingWidget->setting();
 	return ret;
 }

--- a/libs/postbase/title/posttitleeditdialog.ui
+++ b/libs/postbase/title/posttitleeditdialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>368</width>
-    <height>159</height>
+    <width>361</width>
+    <height>174</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -59,75 +59,10 @@
        </item>
       </layout>
      </item>
-     <item row="2" column="0">
-      <widget class="QLabel" name="colorLabel">
-       <property name="text">
-        <string>Color:</string>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="1">
-      <layout class="QHBoxLayout" name="horizontalLayout_3">
-       <item>
-        <widget class="ColorEditWidget" name="colorWidget">
-         <property name="text">
-          <string/>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <spacer name="horizontalSpacer_3">
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>40</width>
-           <height>20</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-      </layout>
-     </item>
-     <item row="3" column="0">
-      <widget class="QLabel" name="fontSizeLabel">
-       <property name="text">
-        <string>Font size:</string>
-       </property>
-      </widget>
-     </item>
-     <item row="3" column="1">
-      <layout class="QHBoxLayout" name="horizontalLayout">
-       <item>
-        <widget class="QSpinBox" name="fontSizeSpinBox">
-         <property name="minimum">
-          <number>6</number>
-         </property>
-         <property name="maximum">
-          <number>40</number>
-         </property>
-         <property name="value">
-          <number>12</number>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <spacer name="horizontalSpacer">
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>40</width>
-           <height>20</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-      </layout>
-     </item>
     </layout>
+   </item>
+   <item>
+    <widget class="vtkTextPropertySettingWidget" name="fontSettingWidget" native="true"/>
    </item>
    <item>
     <spacer name="verticalSpacer">
@@ -156,9 +91,9 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>ColorEditWidget</class>
-   <extends>QLabel</extends>
-   <header>guibase/widget/coloreditwidget.h</header>
+   <class>vtkTextPropertySettingWidget</class>
+   <extends>QWidget</extends>
+   <header>guibase/vtktextpropertysettingwidget.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>

--- a/libs/postbase/title/posttitlesetting.cpp
+++ b/libs/postbase/title/posttitlesetting.cpp
@@ -3,11 +3,12 @@
 #include <QColor>
 
 PostTitleSetting::PostTitleSetting() :
-	CompositeContainer({&title, &fontSize, &color}),
+	CompositeContainer({&title, &fontSetting}),
 	title {"title"},
-	fontSize {"fontSize", 20},
-	color {"color", Qt::black}
-{}
+	fontSetting {}
+{
+	fontSetting.fontSize = 20;
+}
 
 PostTitleSetting::PostTitleSetting(const PostTitleSetting &setting) :
 	PostTitleSetting()

--- a/libs/postbase/title/posttitlesetting.h
+++ b/libs/postbase/title/posttitlesetting.h
@@ -3,9 +3,8 @@
 
 #include "../postbase_global.h"
 
-#include <misc/colorcontainer.h>
+#include <guibase/vtktextpropertysettingcontainer.h>
 #include <misc/compositecontainer.h>
-#include <misc/intcontainer.h>
 #include <misc/stringcontainer.h>
 
 class POSTBASEDLL_EXPORT PostTitleSetting : public CompositeContainer
@@ -17,8 +16,7 @@ public:
 	PostTitleSetting& operator=(const PostTitleSetting& setting);
 
 	StringContainer title;
-	IntContainer fontSize;
-	ColorContainer color;
+	vtkTextPropertySettingContainer fontSetting;
 };
 
 #endif // POSTTITLESETTING_H


### PR DESCRIPTION
This pull request closes #455, #478, #526

These three are all related to font setting on post processing window.
You can check that now you can edit font setting on time, title, and distance measure, just like shown below.

## Time

![time](https://user-images.githubusercontent.com/4031569/61458782-43e11300-a9a6-11e9-9ce1-57a4d58535f2.png)

## Title

![title](https://user-images.githubusercontent.com/4031569/61458797-4e9ba800-a9a6-11e9-8f30-9f2c683ce672.png)

## Distance measure

![distance_measure](https://user-images.githubusercontent.com/4031569/61458810-565b4c80-a9a6-11e9-9f6f-7c1c7f27fc4a.png)
