### PR TITLE
Closes i-RIC/prepost-gui#552

### DIFF
--- a/libs/geodata/pointmap/geodatapointmapwebimporterregionselectdialog.cpp
+++ b/libs/geodata/pointmap/geodatapointmapwebimporterregionselectdialog.cpp
@@ -40,6 +40,9 @@ void GeoDataPointmapWebImporterRegionSelectDialog::setCoordinateSystem(Coordinat
 {
 	double lon, lat;
 	cs->mapGridToGeo(0, 0, &lon, &lat);
+	if (lat < -80 || lat > 80) {
+		lat = 0;
+	}
 
 	ui->mapWidget->setCenter(lon, lat);
 }


### PR DESCRIPTION
The reason that the map does not show was that (0, 0) is mapped to Latitude -90.

With Web Mercator coordinate system, points near North pole and South pole can not be projected properly,

So the code is modified so that in case lat < -80 or lat > 80, the lat is modified to be 0.
