### PR TITLE
Closes i-RIC/prepost-gui#567

### DIFF
--- a/libs/geodata/riversurvey/geodatariversurveycrosssectionwindowgraphicsview.cpp
+++ b/libs/geodata/riversurvey/geodatariversurveycrosssectionwindowgraphicsview.cpp
@@ -167,6 +167,7 @@ void GeoDataRiverSurveyCrosssectionWindowGraphicsView::paintEvent(QPaintEvent* /
 			drawLine(refPoint, c, painter);
 		}
 
+		drawLine(&m_oldLine, Qt::gray, painter);
 		for (int i = 0; i < m_parentWindow->riverPathPoints().count(); ++i) {
 			GeoDataRiverPathPoint* p = m_parentWindow->riverPathPoints().at(i);
 			if (p == nullptr) {continue;}
@@ -1137,6 +1138,7 @@ void GeoDataRiverSurveyCrosssectionWindowGraphicsView::mouseDoubleClickEvent(QMo
 {
 	if (m_mouseEventMode == meEditCrosssection && event->button() == Qt::LeftButton) {
 		m_mouseEventMode = meNormal;
+		m_oldLine.crosssection().AltitudeInfo().clear();
 		updateMouseCursor();
 		viewport()->update();
 	}
@@ -1146,6 +1148,7 @@ void GeoDataRiverSurveyCrosssectionWindowGraphicsView::keyReleaseEvent(QKeyEvent
 {
 	if (m_mouseEventMode == meEditCrosssection && (iRIC::isEnterKey(event->key()) || event->key() == Qt::Key_Escape)) {
 		m_mouseEventMode = meNormal;
+		m_oldLine.crosssection().AltitudeInfo().clear();
 		updateMouseCursor();
 		viewport()->update();
 	}
@@ -1646,6 +1649,7 @@ void GeoDataRiverSurveyCrosssectionWindowGraphicsView::enterEditCrosssectionMode
 	const auto& alist = xsec.AltitudeInfo();
 	const auto& selectedAlt = alist.at(index.row());
 	m_editAltitudePreview = selectedAlt;
+	m_oldLine.crosssection().AltitudeInfo() = alist;
 
 	updateMouseCursor();
 }

--- a/libs/geodata/riversurvey/geodatariversurveycrosssectionwindowgraphicsview.h
+++ b/libs/geodata/riversurvey/geodatariversurveycrosssectionwindowgraphicsview.h
@@ -2,6 +2,7 @@
 #define GEODATARIVERSURVEYCROSSSECTIONWINDOWGRAPHICSVIEW_H
 
 #include "geodatarivercrosssection.h"
+#include "geodatariverpathpoint.h"
 
 #include <QAbstractItemView>
 
@@ -164,6 +165,7 @@ private:
 	QPoint m_dragStartPoint;
 	QMatrix m_matrix;
 	GeoDataRiverCrosssection::Altitude m_editAltitudePreview;
+	GeoDataRiverPathPoint m_oldLine;
 	QString m_editRatio;
 	bool m_gridMode;
 };


### PR DESCRIPTION
Please test this by the following operations:

1. Start new project
2. Import the attached *.riv file
3. Select a cross section, and select "Display Cross Section" from right-clicking menu.
4. Select a point, and select "Edit cross section from the selected point".
5. You'll see that when you edit the cross section, the old shape is shown as gray line.

[issue-567.zip](https://github.com/i-RIC/prepost-gui/files/3829421/issue-567.zip)
