### PR TITLE
Closes i-RIC/prepost-gui#656

### DIFF
--- a/libs/guicore/pre/grid/gridexporterinterface.h
+++ b/libs/guicore/pre/grid/gridexporterinterface.h
@@ -4,7 +4,9 @@
 #include "../../solverdef/solverdefinitiongridtype.h"
 #include <QtPlugin>
 
+class CoordinateSystem;
 class Grid;
+
 class QString;
 class QStringList;
 class QWidget;
@@ -21,7 +23,7 @@ public:
 	/// Return filter string for QFileDialog
 	virtual QStringList fileDialogFilters() const = 0;
 	/// Export grid data into external file.
-	virtual bool doExport(Grid* grid, const QString& filename, const QString& selectedFilter, QWidget* parent) = 0;
+	virtual bool doExport(Grid* grid, const QString& filename, const QString& selectedFilter, CoordinateSystem* cs, QWidget* parent) = 0;
 };
 
 #define GridExporterInterface_iid "org.iric.GUI.Plugin.GridExporterInterface"

--- a/libs/pre/datamodel/preprocessorgriddataitem.cpp
+++ b/libs/pre/datamodel/preprocessorgriddataitem.cpp
@@ -31,6 +31,7 @@
 #include <guicore/pre/gridcond/base/gridattributecontainer.h>
 #include <guicore/project/projectcgnsfile.h>
 #include <guicore/project/projectdata.h>
+#include <guicore/project/projectmainfile.h>
 #include <guicore/solverdef/solverdefinitiongridattribute.h>
 #include <guicore/solverdef/solverdefinitiongridtype.h>
 #include <misc/errormessage.h>
@@ -329,7 +330,8 @@ EXPORT_ERROR_BEFORE_OPEN:
 EXPORT_SUCCEED:
 		;
 	} else {
-		ret = exporter->doExport(impl->m_grid, filename, selectedFilter, projectData()->mainWindow());
+		auto cs = projectData()->mainfile()->coordinateSystem();
+		ret = exporter->doExport(impl->m_grid, filename, selectedFilter, cs, projectData()->mainWindow());
 	}
 	if (ret) {
 		// exporting succeeded.

--- a/libs/pre/gridexporter/cgnsgridexporter.cpp
+++ b/libs/pre/gridexporter/cgnsgridexporter.cpp
@@ -30,7 +30,7 @@ QStringList CgnsGridExporter::fileDialogFilters() const
 	return ret;
 }
 
-bool CgnsGridExporter::doExport(Grid* grid, const QString& filename, const QString& /*selectedFilter*/, QWidget* /*parent*/)
+bool CgnsGridExporter::doExport(Grid* grid, const QString& filename, const QString& /*selectedFilter*/, CoordinateSystem* /*cs*/, QWidget* /*parent*/)
 {
 	QString tmpname;
 	int fn, B;

--- a/libs/pre/gridexporter/cgnsgridexporter.h
+++ b/libs/pre/gridexporter/cgnsgridexporter.h
@@ -16,7 +16,7 @@ public:
 	bool isGridTypeSupported(SolverDefinitionGridType::GridType /*gt*/) const override {
 		return true;
 	}
-	bool doExport(Grid* grid, const QString& filename, const QString& selectedFilter, QWidget* parent) override;
+	bool doExport(Grid* grid, const QString& filename, const QString& selectedFilter, CoordinateSystem* cs, QWidget* parent) override;
 	bool createTempCgns(Grid* grid, QString& tmpname, int& fn, int& B);
 	bool closeAndMoveCgns(const QString& tmpname, int fn, const QString& cgnsname);
 };

--- a/plugins/gridexporter/gridlandxmlexporter/gridlandxmlexporter.cpp
+++ b/plugins/gridexporter/gridlandxmlexporter/gridlandxmlexporter.cpp
@@ -41,7 +41,7 @@ QStringList GridLandXmlExporter::fileDialogFilters() const
 	return ret;
 }
 
-bool GridLandXmlExporter::doExport(Grid* grid, const QString& filename, const QString& /*selectedFilter*/, QWidget* parent)
+bool GridLandXmlExporter::doExport(Grid* grid, const QString& filename, const QString& /*selectedFilter*/, CoordinateSystem* cs, QWidget* parent)
 {
 	QFile file(filename);
 	if (! file.open(QIODevice::WriteOnly)) {
@@ -57,7 +57,7 @@ bool GridLandXmlExporter::doExport(Grid* grid, const QString& filename, const QS
 
 	LandXmlUtil::writeProjectForMlit(&writer, "grid");
 	LandXmlUtil::writeApplication(&writer);
-	// @todo CoordinateSystem
+	LandXmlUtil::writeCoordinateSystem(&writer, cs);
 	LandXmlUtil::writeUnits(&writer);
 
 	writer.writeStartElement("Surfaces");

--- a/plugins/gridexporter/gridlandxmlexporter/gridlandxmlexporter.h
+++ b/plugins/gridexporter/gridlandxmlexporter/gridlandxmlexporter.h
@@ -16,7 +16,7 @@ public:
 	QString caption() const override;
 	bool isGridTypeSupported(SolverDefinitionGridType::GridType gt) const override;
 	QStringList fileDialogFilters() const override;
-	bool doExport(Grid* grid, const QString& filename, const QString& selectedFilter, QWidget* parent) override;
+	bool doExport(Grid* grid, const QString& filename, const QString& selectedFilter, CoordinateSystem* cs, QWidget* parent) override;
 };
 
 #endif // GRIDLANDXMLEXPORTER_H

--- a/plugins/gridexporter/structured2dgridnayscsvexporter/structured2dgridnayscsvexporter.cpp
+++ b/plugins/gridexporter/structured2dgridnayscsvexporter/structured2dgridnayscsvexporter.cpp
@@ -109,7 +109,7 @@ QStringList Structured2DGridNaysCSVExporter::fileDialogFilters() const
 	return ret;
 }
 
-bool Structured2DGridNaysCSVExporter::doExport(Grid* grid, const QString& filename, const QString& /*selectedFilter*/, QWidget* /*parent*/)
+bool Structured2DGridNaysCSVExporter::doExport(Grid* grid, const QString& filename, const QString& /*selectedFilter*/, CoordinateSystem* /*cs*/, QWidget* /*parent*/)
 {
 	Structured2DGrid* grid2d = dynamic_cast<Structured2DGrid*>(grid);
 	int imax = grid2d->dimensionI();

--- a/plugins/gridexporter/structured2dgridnayscsvexporter/structured2dgridnayscsvexporter.h
+++ b/plugins/gridexporter/structured2dgridnayscsvexporter/structured2dgridnayscsvexporter.h
@@ -16,7 +16,7 @@ public:
 	QString caption() const override;
 	bool isGridTypeSupported(SolverDefinitionGridType::GridType gt) const override;
 	QStringList fileDialogFilters() const override;
-	bool doExport(Grid* grid, const QString& filename, const QString& selectedFilter, QWidget* parent) override;
+	bool doExport(Grid* grid, const QString& filename, const QString& selectedFilter, CoordinateSystem* cs, QWidget* parent) override;
 };
 
 #endif // STRUCTURED2DGRIDNAYSCSVEXPORTER_H

--- a/plugins/gridexporter/structured2dgridnaysgridexporter/structured2dgridnaysgridexporter.cpp
+++ b/plugins/gridexporter/structured2dgridnaysgridexporter/structured2dgridnaysgridexporter.cpp
@@ -24,7 +24,7 @@ QStringList Structured2DGridNaysGridExporter::fileDialogFilters() const
 	return ret;
 }
 
-bool Structured2DGridNaysGridExporter::doExport(Grid* grid, const QString& filename, const QString& /*selectedFilter*/, QWidget* /*parent*/)
+bool Structured2DGridNaysGridExporter::doExport(Grid* grid, const QString& filename, const QString& /*selectedFilter*/, CoordinateSystem* /*cs*/, QWidget* /*parent*/)
 {
 	Structured2DGrid* grid2d = dynamic_cast<Structured2DGrid*>(grid);
 

--- a/plugins/gridexporter/structured2dgridnaysgridexporter/structured2dgridnaysgridexporter.h
+++ b/plugins/gridexporter/structured2dgridnaysgridexporter/structured2dgridnaysgridexporter.h
@@ -19,7 +19,7 @@ public:
 		return gt == SolverDefinitionGridType::gtStructured2DGrid;
 	}
 	QStringList fileDialogFilters() const override;
-	bool doExport(Grid* grid, const QString& filename, const QString& selectedFilter, QWidget* parent) override;
+	bool doExport(Grid* grid, const QString& filename, const QString& selectedFilter, CoordinateSystem* cs, QWidget* parent) override;
 };
 
 #endif // STRUCTURED2DGRIDNAYSGRIDEXPORTER_H

--- a/plugins/gridexporter/structured2dgridvtkexporter/structured2dgridvtkexporter.cpp
+++ b/plugins/gridexporter/structured2dgridvtkexporter/structured2dgridvtkexporter.cpp
@@ -33,7 +33,7 @@ QStringList Structured2DGridVTKExporter::fileDialogFilters() const
 	return ret;
 }
 
-bool Structured2DGridVTKExporter::doExport(Grid* grid, const QString& filename, const QString& /*selectedFilter*/, QWidget* /*parent*/)
+bool Structured2DGridVTKExporter::doExport(Grid* grid, const QString& filename, const QString& /*selectedFilter*/, CoordinateSystem* /*cs*/, QWidget* /*parent*/)
 {
 	QString tempPath = QDir::tempPath();
 	QString tmpFile = iRIC::getTempFileName(tempPath);

--- a/plugins/gridexporter/structured2dgridvtkexporter/structured2dgridvtkexporter.h
+++ b/plugins/gridexporter/structured2dgridvtkexporter/structured2dgridvtkexporter.h
@@ -16,7 +16,7 @@ public:
 	QString caption() const override;
 	bool isGridTypeSupported(SolverDefinitionGridType::GridType gt) const override;
 	QStringList fileDialogFilters() const override;
-	bool doExport(Grid* grid, const QString& filename, const QString& selectedFilter, QWidget* parent) override;
+	bool doExport(Grid* grid, const QString& filename, const QString& selectedFilter, CoordinateSystem* cs, QWidget* parent) override;
 };
 
 #endif // STRUCTURED2DGRIDVTKEXPORTER_H

--- a/plugins/gridexporter/unstructured2dgridvtkexporter/unstructured2dgridvtkexporter.cpp
+++ b/plugins/gridexporter/unstructured2dgridvtkexporter/unstructured2dgridvtkexporter.cpp
@@ -31,7 +31,7 @@ QStringList Unstructured2DGridVTKExporter::fileDialogFilters() const
 	return ret;
 }
 
-bool Unstructured2DGridVTKExporter::doExport(Grid* grid, const QString& filename, const QString& /*selectedFilter*/, QWidget* /*parent*/)
+bool Unstructured2DGridVTKExporter::doExport(Grid* grid, const QString& filename, const QString& /*selectedFilter*/, CoordinateSystem* /*cs*/, QWidget* /*parent*/)
 {
 	QString tempPath = QDir::tempPath();
 	QString tmpFile = iRIC::getTempFileName(tempPath);

--- a/plugins/gridexporter/unstructured2dgridvtkexporter/unstructured2dgridvtkexporter.h
+++ b/plugins/gridexporter/unstructured2dgridvtkexporter/unstructured2dgridvtkexporter.h
@@ -15,7 +15,7 @@ public:
 	QString caption() const override;
 	bool isGridTypeSupported(SolverDefinitionGridType::GridType gt) const override;
 	QStringList fileDialogFilters() const override;
-	bool doExport(Grid* grid, const QString& filename, const QString& selectedFilter, QWidget* parent) override;
+	bool doExport(Grid* grid, const QString& filename, const QString& selectedFilter, CoordinateSystem* cs, QWidget* parent) override;
 };
 
 #endif // UNSTRUCTURED2DGRIDVTKEXPORTER_H


### PR DESCRIPTION
Please test with the attached file. 

Please note that to test this, you should do the following operations.

1. Build in release mode
2. Copy dlls in libdlls/release to C:\Users(Username)\iRIC\guis\prepost
3. Create C:\Users(Username)\iRIC\gridexporter_plugins\gridlandxmlexporter
4. Copy plugins\gridexporter\gridlandxmlexporter\release\gridlandxmlexporter.dll to the folder you created in 3.

To test this, please do the following operations.

1. Open issue-656.zip (rename it to issue-656.ipro)
2. Select Grid -> Export
3. Select "LandXml files (*.xml) from "File Type" combobox
4. Save as test.xml

You can check that the new version output the following element in the XML.

```
<CoordinateSystem epsgCode="2455" name="EPSG:2455: JGD2000 / Japan Plane Rectangular CS XIII"/>
```
[issue-656.zip](https://github.com/i-RIC/prepost-gui/files/4076599/issue-656.zip)
