### PR TITLE
Closes i-RIC/prepost-gui#669

### DIFF
--- a/libs/gui/continuoussnapshot/continuoussnapshotconfirmpage.cpp
+++ b/libs/gui/continuoussnapshot/continuoussnapshotconfirmpage.cpp
@@ -46,7 +46,7 @@ void ContinuousSnapshotConfirmPage::initializePage()
 	}
 	if (m_wizard->outputMovie()) {
 		for (const QString& prefix : m_wizard->prefixList()) {
-			QString movieFilename = QString("%1.wmv").arg(prefix);
+			QString movieFilename = QString("%1.mp4").arg(prefix);
 			QString absMovieFilename = QDir(m_wizard->fileIODirectory()).absoluteFilePath(movieFilename);
 			m_fileList->addItem(QDir::toNativeSeparators(absMovieFilename));
 		}

--- a/libs/gui/continuoussnapshot/continuoussnapshotmoviepropertypage.cpp
+++ b/libs/gui/continuoussnapshot/continuoussnapshotmoviepropertypage.cpp
@@ -33,14 +33,14 @@ void ContinuousSnapshotMoviePropertyPage::initializePage()
 	case ContinuousSnapshotWizard::Onefile:
 		ui->filenameTableWidget->setRowCount(1);
 		ui->filenameTableWidget->setVerticalHeaderItem(0, new QTableWidgetItem(tr("Output file")));
-		ui->filenameTableWidget->setItem(0, 0, new QTableWidgetItem("img.wmv"));
+		ui->filenameTableWidget->setItem(0, 0, new QTableWidgetItem("img.mp4"));
 		break;
 	case ContinuousSnapshotWizard::Respectively:
 		ui->filenameTableWidget->setRowCount(m_wizard->windowList().size());
 		int idx = 0;
 		for (QMdiSubWindow* sub : m_wizard->windowList()) {
 			ui->filenameTableWidget->setVerticalHeaderItem(idx, new QTableWidgetItem(sub->windowTitle()));
-			ui->filenameTableWidget->setItem(idx, 0, new QTableWidgetItem(QString("window%1.wmv").arg(idx + 1)));
+			ui->filenameTableWidget->setItem(idx, 0, new QTableWidgetItem(QString("window%1.mp4").arg(idx + 1)));
 			++idx;
 		}
 		break;
@@ -87,7 +87,7 @@ QStringList ContinuousSnapshotMoviePropertyPage::getProfile(int profileid)
 	switch (profileid) {
 	case 0:
 	default:
-		ret << "-qscale" << "0" << "-vcodec" << "wmv2";
+		ret << "-qscale" << "0" << "-vcodec" << "libx264" << "-pix_fmt" << "yuv420p";
 		break;
 	}
 	return ret;

--- a/libs/gui/main/iricmainwindow.cpp
+++ b/libs/gui/main/iricmainwindow.cpp
@@ -1094,7 +1094,7 @@ void iRICMainWindow::saveContinuousSnapshot(ContinuousSnapshotWizard* wizard, QX
 		switch (wizard->output()) {
 		case ContinuousSnapshotWizard::Onefile:
 			inputFilename = QString("img_%%1d%2").arg(wizard->suffixLength()).arg(wizard->extension());
-			outputFilename = QString("img.wmv");
+			outputFilename = QString("img.mp4");
 			inputFilenames.append(inputFilename);
 			outputFilenames.append(outputFilename);
 			break;
@@ -1102,7 +1102,7 @@ void iRICMainWindow::saveContinuousSnapshot(ContinuousSnapshotWizard* wizard, QX
 			int idx = 0;
 			for (auto it = wizard->windowList().begin(); it != wizard->windowList().end(); ++it) {
 				inputFilename = QString("window%1_%%2d%3").arg(idx + 1).arg(wizard->suffixLength()).arg(wizard->extension());
-				outputFilename = QString("window%1.wmv").arg(idx + 1);
+				outputFilename = QString("window%1.mp4").arg(idx + 1);
 				inputFilenames.append(inputFilename);
 				outputFilenames.append(outputFilename);
 				++idx;


### PR DESCRIPTION
You can test with the attached file below.
When user export movie, the extension is mp4, and can be played with Windows media player, iPhone etc.

[issue-669.zip](https://github.com/i-RIC/prepost-gui/files/4120855/issue-669.zip)
