### PR TITLE
Closes #747

### DIFF
--- a/libs/guicore/pre/gridcond/base/gridattributecontainer.cpp
+++ b/libs/guicore/pre/gridcond/base/gridattributecontainer.cpp
@@ -68,14 +68,20 @@ void GridAttributeContainer::setCustomModified(bool c)
 void GridAttributeContainer::updateConnections()
 {
 	GridAttributeDimensionsContainer* dims = dimensions();
+	// avoid duplication
+	disconnect(dims, SIGNAL(currentIndexChanged(int, int)), this, SLOT(handleDimensionCurrentIndexChange(int, int)));
 	connect(dims, SIGNAL(currentIndexChanged(int,int)), this, SLOT(handleDimensionCurrentIndexChange(int,int)));
 	for (auto cont : dims->containers()) {
-		connect(cont, SIGNAL(valuesChanged(std::vector<QVariant>,std::vector<QVariant>)), this, SLOT(handleDimensionValuesChange(std::vector<QVariant>,std::vector<QVariant>)));
+		// avoid duplication
+		disconnect(cont, SIGNAL(valuesChanged(std::vector<QVariant>, std::vector<QVariant>)), this, SLOT(handleDimensionValuesChange(std::vector<QVariant>, std::vector<QVariant>)));
+		connect(cont, SIGNAL(valuesChanged(std::vector<QVariant>, std::vector<QVariant>)), this, SLOT(handleDimensionValuesChange(std::vector<QVariant>, std::vector<QVariant>)));
 	}
 }
 
 void GridAttributeContainer::handleDimensionCurrentIndexChange(int oldIndex, int newIndex)
 {
+	if (oldIndex == newIndex) {return;}
+
 	QString fname = temporaryExternalFilename(oldIndex);
 	QFileInfo finfo(fname);
 	iRIC::mkdirRecursively(finfo.absolutePath());


### PR DESCRIPTION
To test this pull request, please test with the following procedure:

1. Open issue-747.ipro
2. Select "Grid (no data)" in Object browser, and select "Import" from right-clicking menu
3. Import grid from rain_20200623_0000.asc
4. Select menu "Grid" -> "Attribute Mapping" -> "Execute", and map Xrain.
5. Check on "Grid" / "Cell attributes" / "Xrain", and compare with data in "Geographic Data" / Xrain / "Raster data1".

Without this patch, wrong data is mapped, like below:

![screenshot1](https://user-images.githubusercontent.com/4031569/85573600-ffa7c980-b670-11ea-928a-5ac0c7c440ca.png)

With this patch, data is correctly maped, like below:

![screenshot2](https://user-images.githubusercontent.com/4031569/85573609-020a2380-b671-11ea-87bb-2edbdf8710a5.png)

Please note that you need "Structured grid GDAL importer" plugin for operation 3. It is a rather new function, so maybe it is not in your environment. Please use iRIC Maintainance to install it.

[issue-747.zip](https://github.com/i-RIC/prepost-gui/files/4825938/issue-747.zip)

It is a bug fix pull request, so we merge it to develop branch first, and if it looks OK, I also will merge this to master branch. 