### PR TITLE
Closes #793, #817

### DIFF
--- a/languages/iRIC_ar_EG.ts
+++ b/languages/iRIC_ar_EG.ts
@@ -2526,6 +2526,84 @@ p, li { white-space: pre-wrap; }
     </message>
 </context>
 <context>
+    <name>GeoDataPointGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPointGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Points)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Points) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPointGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>
@@ -3597,6 +3675,116 @@ p, li { white-space: pre-wrap; }
     </message>
 </context>
 <context>
+    <name>GeoDataPolygonGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Some polygon in this polygon group has holes, but holes are not exported to CSV file. If you want to export holes, please export to ESRI Shapefile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolygonGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polygons)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polygons) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Polygon should have three points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;pid&quot; value in line %1. &quot;pid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolygonGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>
@@ -3903,6 +4091,108 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>Polyline</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polylines)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polylines) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Line should have two points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;lid&quot; value in line %1. &quot;lid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/languages/iRIC_ar_EG.ts
+++ b/languages/iRIC_ar_EG.ts
@@ -3323,6 +3323,14 @@ p, li { white-space: pre-wrap; }
         <source>Finish Defining Point</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeoDataPointColorSimpleSettingDialog</name>

--- a/languages/iRIC_bg_BG.ts
+++ b/languages/iRIC_bg_BG.ts
@@ -2526,6 +2526,84 @@ p, li { white-space: pre-wrap; }
     </message>
 </context>
 <context>
+    <name>GeoDataPointGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPointGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Points)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Points) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPointGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>
@@ -3597,6 +3675,116 @@ p, li { white-space: pre-wrap; }
     </message>
 </context>
 <context>
+    <name>GeoDataPolygonGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Some polygon in this polygon group has holes, but holes are not exported to CSV file. If you want to export holes, please export to ESRI Shapefile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolygonGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polygons)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polygons) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Polygon should have three points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;pid&quot; value in line %1. &quot;pid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolygonGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>
@@ -3903,6 +4091,108 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>Polyline</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polylines)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polylines) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Line should have two points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;lid&quot; value in line %1. &quot;lid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/languages/iRIC_bg_BG.ts
+++ b/languages/iRIC_bg_BG.ts
@@ -3323,6 +3323,14 @@ p, li { white-space: pre-wrap; }
         <source>Finish Defining Point</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeoDataPointColorSimpleSettingDialog</name>

--- a/languages/iRIC_bs_BA.ts
+++ b/languages/iRIC_bs_BA.ts
@@ -2526,6 +2526,84 @@ p, li { white-space: pre-wrap; }
     </message>
 </context>
 <context>
+    <name>GeoDataPointGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPointGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Points)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Points) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPointGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>
@@ -3597,6 +3675,116 @@ p, li { white-space: pre-wrap; }
     </message>
 </context>
 <context>
+    <name>GeoDataPolygonGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Some polygon in this polygon group has holes, but holes are not exported to CSV file. If you want to export holes, please export to ESRI Shapefile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolygonGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polygons)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polygons) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Polygon should have three points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;pid&quot; value in line %1. &quot;pid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolygonGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>
@@ -3903,6 +4091,108 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>Polyline</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polylines)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polylines) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Line should have two points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;lid&quot; value in line %1. &quot;lid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/languages/iRIC_bs_BA.ts
+++ b/languages/iRIC_bs_BA.ts
@@ -3323,6 +3323,14 @@ p, li { white-space: pre-wrap; }
         <source>Finish Defining Point</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeoDataPointColorSimpleSettingDialog</name>

--- a/languages/iRIC_ca_ES.ts
+++ b/languages/iRIC_ca_ES.ts
@@ -2526,6 +2526,84 @@ p, li { white-space: pre-wrap; }
     </message>
 </context>
 <context>
+    <name>GeoDataPointGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPointGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Points)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Points) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPointGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>
@@ -3597,6 +3675,116 @@ p, li { white-space: pre-wrap; }
     </message>
 </context>
 <context>
+    <name>GeoDataPolygonGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Some polygon in this polygon group has holes, but holes are not exported to CSV file. If you want to export holes, please export to ESRI Shapefile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolygonGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polygons)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polygons) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Polygon should have three points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;pid&quot; value in line %1. &quot;pid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolygonGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>
@@ -3903,6 +4091,108 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>Polyline</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polylines)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polylines) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Line should have two points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;lid&quot; value in line %1. &quot;lid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/languages/iRIC_ca_ES.ts
+++ b/languages/iRIC_ca_ES.ts
@@ -3323,6 +3323,14 @@ p, li { white-space: pre-wrap; }
         <source>Finish Defining Point</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeoDataPointColorSimpleSettingDialog</name>

--- a/languages/iRIC_cs_CZ.ts
+++ b/languages/iRIC_cs_CZ.ts
@@ -2526,6 +2526,84 @@ p, li { white-space: pre-wrap; }
     </message>
 </context>
 <context>
+    <name>GeoDataPointGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPointGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Points)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Points) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPointGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>
@@ -3597,6 +3675,116 @@ p, li { white-space: pre-wrap; }
     </message>
 </context>
 <context>
+    <name>GeoDataPolygonGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Some polygon in this polygon group has holes, but holes are not exported to CSV file. If you want to export holes, please export to ESRI Shapefile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolygonGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polygons)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polygons) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Polygon should have three points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;pid&quot; value in line %1. &quot;pid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolygonGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>
@@ -3903,6 +4091,108 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>Polyline</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polylines)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polylines) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Line should have two points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;lid&quot; value in line %1. &quot;lid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/languages/iRIC_cs_CZ.ts
+++ b/languages/iRIC_cs_CZ.ts
@@ -3323,6 +3323,14 @@ p, li { white-space: pre-wrap; }
         <source>Finish Defining Point</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeoDataPointColorSimpleSettingDialog</name>

--- a/languages/iRIC_da_DK.ts
+++ b/languages/iRIC_da_DK.ts
@@ -2526,6 +2526,84 @@ p, li { white-space: pre-wrap; }
     </message>
 </context>
 <context>
+    <name>GeoDataPointGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPointGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Points)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Points) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPointGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>
@@ -3597,6 +3675,116 @@ p, li { white-space: pre-wrap; }
     </message>
 </context>
 <context>
+    <name>GeoDataPolygonGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Some polygon in this polygon group has holes, but holes are not exported to CSV file. If you want to export holes, please export to ESRI Shapefile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolygonGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polygons)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polygons) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Polygon should have three points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;pid&quot; value in line %1. &quot;pid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolygonGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>
@@ -3903,6 +4091,108 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>Polyline</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polylines)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polylines) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Line should have two points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;lid&quot; value in line %1. &quot;lid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/languages/iRIC_da_DK.ts
+++ b/languages/iRIC_da_DK.ts
@@ -3323,6 +3323,14 @@ p, li { white-space: pre-wrap; }
         <source>Finish Defining Point</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeoDataPointColorSimpleSettingDialog</name>

--- a/languages/iRIC_de_DE.ts
+++ b/languages/iRIC_de_DE.ts
@@ -2526,6 +2526,84 @@ p, li { white-space: pre-wrap; }
     </message>
 </context>
 <context>
+    <name>GeoDataPointGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPointGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Points)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Points) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPointGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>
@@ -3597,6 +3675,116 @@ p, li { white-space: pre-wrap; }
     </message>
 </context>
 <context>
+    <name>GeoDataPolygonGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Some polygon in this polygon group has holes, but holes are not exported to CSV file. If you want to export holes, please export to ESRI Shapefile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolygonGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polygons)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polygons) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Polygon should have three points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;pid&quot; value in line %1. &quot;pid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolygonGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>
@@ -3903,6 +4091,108 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>Polyline</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polylines)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polylines) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Line should have two points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;lid&quot; value in line %1. &quot;lid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/languages/iRIC_de_DE.ts
+++ b/languages/iRIC_de_DE.ts
@@ -3323,6 +3323,14 @@ p, li { white-space: pre-wrap; }
         <source>Finish Defining Point</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeoDataPointColorSimpleSettingDialog</name>

--- a/languages/iRIC_el_GR.ts
+++ b/languages/iRIC_el_GR.ts
@@ -2526,6 +2526,84 @@ p, li { white-space: pre-wrap; }
     </message>
 </context>
 <context>
+    <name>GeoDataPointGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPointGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Points)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Points) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPointGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>
@@ -3597,6 +3675,116 @@ p, li { white-space: pre-wrap; }
     </message>
 </context>
 <context>
+    <name>GeoDataPolygonGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Some polygon in this polygon group has holes, but holes are not exported to CSV file. If you want to export holes, please export to ESRI Shapefile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolygonGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polygons)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polygons) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Polygon should have three points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;pid&quot; value in line %1. &quot;pid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolygonGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>
@@ -3903,6 +4091,108 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>Polyline</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polylines)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polylines) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Line should have two points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;lid&quot; value in line %1. &quot;lid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/languages/iRIC_el_GR.ts
+++ b/languages/iRIC_el_GR.ts
@@ -3323,6 +3323,14 @@ p, li { white-space: pre-wrap; }
         <source>Finish Defining Point</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeoDataPointColorSimpleSettingDialog</name>

--- a/languages/iRIC_es_ES.ts
+++ b/languages/iRIC_es_ES.ts
@@ -3398,6 +3398,14 @@ p, li { white-space: pre-wrap; }
         <source>Finish Defining Point</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeoDataPointColorSimpleSettingDialog</name>

--- a/languages/iRIC_es_ES.ts
+++ b/languages/iRIC_es_ES.ts
@@ -2601,6 +2601,84 @@ p, li { white-space: pre-wrap; }
     </message>
 </context>
 <context>
+    <name>GeoDataPointGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPointGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Points)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Points) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPointGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>
@@ -3742,6 +3820,116 @@ p, li { white-space: pre-wrap; }
     </message>
 </context>
 <context>
+    <name>GeoDataPolygonGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation type="unfinished">Aviso</translation>
+    </message>
+    <message>
+        <source>Some polygon in this polygon group has holes, but holes are not exported to CSV file. If you want to export holes, please export to ESRI Shapefile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolygonGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polygons)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polygons) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Polygon should have three points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;pid&quot; value in line %1. &quot;pid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolygonGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>
@@ -4095,6 +4283,108 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>Polyline</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polylines)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polylines) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Line should have two points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;lid&quot; value in line %1. &quot;lid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/languages/iRIC_et_EE.ts
+++ b/languages/iRIC_et_EE.ts
@@ -2526,6 +2526,84 @@ p, li { white-space: pre-wrap; }
     </message>
 </context>
 <context>
+    <name>GeoDataPointGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPointGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Points)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Points) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPointGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>
@@ -3597,6 +3675,116 @@ p, li { white-space: pre-wrap; }
     </message>
 </context>
 <context>
+    <name>GeoDataPolygonGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Some polygon in this polygon group has holes, but holes are not exported to CSV file. If you want to export holes, please export to ESRI Shapefile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolygonGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polygons)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polygons) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Polygon should have three points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;pid&quot; value in line %1. &quot;pid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolygonGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>
@@ -3903,6 +4091,108 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>Polyline</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polylines)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polylines) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Line should have two points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;lid&quot; value in line %1. &quot;lid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/languages/iRIC_et_EE.ts
+++ b/languages/iRIC_et_EE.ts
@@ -3323,6 +3323,14 @@ p, li { white-space: pre-wrap; }
         <source>Finish Defining Point</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeoDataPointColorSimpleSettingDialog</name>

--- a/languages/iRIC_eu_ES.ts
+++ b/languages/iRIC_eu_ES.ts
@@ -2526,6 +2526,84 @@ p, li { white-space: pre-wrap; }
     </message>
 </context>
 <context>
+    <name>GeoDataPointGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPointGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Points)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Points) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPointGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>
@@ -3597,6 +3675,116 @@ p, li { white-space: pre-wrap; }
     </message>
 </context>
 <context>
+    <name>GeoDataPolygonGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Some polygon in this polygon group has holes, but holes are not exported to CSV file. If you want to export holes, please export to ESRI Shapefile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolygonGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polygons)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polygons) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Polygon should have three points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;pid&quot; value in line %1. &quot;pid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolygonGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>
@@ -3903,6 +4091,108 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>Polyline</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polylines)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polylines) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Line should have two points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;lid&quot; value in line %1. &quot;lid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/languages/iRIC_eu_ES.ts
+++ b/languages/iRIC_eu_ES.ts
@@ -3323,6 +3323,14 @@ p, li { white-space: pre-wrap; }
         <source>Finish Defining Point</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeoDataPointColorSimpleSettingDialog</name>

--- a/languages/iRIC_fi_FI.ts
+++ b/languages/iRIC_fi_FI.ts
@@ -2526,6 +2526,84 @@ p, li { white-space: pre-wrap; }
     </message>
 </context>
 <context>
+    <name>GeoDataPointGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPointGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Points)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Points) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPointGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>
@@ -3597,6 +3675,116 @@ p, li { white-space: pre-wrap; }
     </message>
 </context>
 <context>
+    <name>GeoDataPolygonGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Some polygon in this polygon group has holes, but holes are not exported to CSV file. If you want to export holes, please export to ESRI Shapefile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolygonGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polygons)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polygons) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Polygon should have three points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;pid&quot; value in line %1. &quot;pid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolygonGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>
@@ -3903,6 +4091,108 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>Polyline</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polylines)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polylines) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Line should have two points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;lid&quot; value in line %1. &quot;lid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/languages/iRIC_fi_FI.ts
+++ b/languages/iRIC_fi_FI.ts
@@ -3323,6 +3323,14 @@ p, li { white-space: pre-wrap; }
         <source>Finish Defining Point</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeoDataPointColorSimpleSettingDialog</name>

--- a/languages/iRIC_fr_FR.ts
+++ b/languages/iRIC_fr_FR.ts
@@ -2526,6 +2526,84 @@ p, li { white-space: pre-wrap; }
     </message>
 </context>
 <context>
+    <name>GeoDataPointGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPointGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Points)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Points) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPointGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>
@@ -3597,6 +3675,116 @@ p, li { white-space: pre-wrap; }
     </message>
 </context>
 <context>
+    <name>GeoDataPolygonGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Some polygon in this polygon group has holes, but holes are not exported to CSV file. If you want to export holes, please export to ESRI Shapefile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolygonGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polygons)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polygons) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Polygon should have three points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;pid&quot; value in line %1. &quot;pid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolygonGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>
@@ -3903,6 +4091,108 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>Polyline</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polylines)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polylines) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Line should have two points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;lid&quot; value in line %1. &quot;lid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/languages/iRIC_fr_FR.ts
+++ b/languages/iRIC_fr_FR.ts
@@ -3323,6 +3323,14 @@ p, li { white-space: pre-wrap; }
         <source>Finish Defining Point</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeoDataPointColorSimpleSettingDialog</name>

--- a/languages/iRIC_gl_ES.ts
+++ b/languages/iRIC_gl_ES.ts
@@ -2526,6 +2526,84 @@ p, li { white-space: pre-wrap; }
     </message>
 </context>
 <context>
+    <name>GeoDataPointGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPointGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Points)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Points) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPointGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>
@@ -3597,6 +3675,116 @@ p, li { white-space: pre-wrap; }
     </message>
 </context>
 <context>
+    <name>GeoDataPolygonGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Some polygon in this polygon group has holes, but holes are not exported to CSV file. If you want to export holes, please export to ESRI Shapefile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolygonGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polygons)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polygons) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Polygon should have three points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;pid&quot; value in line %1. &quot;pid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolygonGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>
@@ -3903,6 +4091,108 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>Polyline</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polylines)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polylines) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Line should have two points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;lid&quot; value in line %1. &quot;lid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/languages/iRIC_gl_ES.ts
+++ b/languages/iRIC_gl_ES.ts
@@ -3323,6 +3323,14 @@ p, li { white-space: pre-wrap; }
         <source>Finish Defining Point</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeoDataPointColorSimpleSettingDialog</name>

--- a/languages/iRIC_hi_IN.ts
+++ b/languages/iRIC_hi_IN.ts
@@ -2526,6 +2526,84 @@ p, li { white-space: pre-wrap; }
     </message>
 </context>
 <context>
+    <name>GeoDataPointGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPointGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Points)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Points) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPointGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>
@@ -3597,6 +3675,116 @@ p, li { white-space: pre-wrap; }
     </message>
 </context>
 <context>
+    <name>GeoDataPolygonGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Some polygon in this polygon group has holes, but holes are not exported to CSV file. If you want to export holes, please export to ESRI Shapefile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolygonGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polygons)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polygons) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Polygon should have three points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;pid&quot; value in line %1. &quot;pid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolygonGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>
@@ -3903,6 +4091,108 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>Polyline</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polylines)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polylines) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Line should have two points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;lid&quot; value in line %1. &quot;lid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/languages/iRIC_hi_IN.ts
+++ b/languages/iRIC_hi_IN.ts
@@ -3323,6 +3323,14 @@ p, li { white-space: pre-wrap; }
         <source>Finish Defining Point</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeoDataPointColorSimpleSettingDialog</name>

--- a/languages/iRIC_hu_HU.ts
+++ b/languages/iRIC_hu_HU.ts
@@ -2526,6 +2526,84 @@ p, li { white-space: pre-wrap; }
     </message>
 </context>
 <context>
+    <name>GeoDataPointGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPointGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Points)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Points) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPointGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>
@@ -3597,6 +3675,116 @@ p, li { white-space: pre-wrap; }
     </message>
 </context>
 <context>
+    <name>GeoDataPolygonGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Some polygon in this polygon group has holes, but holes are not exported to CSV file. If you want to export holes, please export to ESRI Shapefile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolygonGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polygons)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polygons) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Polygon should have three points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;pid&quot; value in line %1. &quot;pid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolygonGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>
@@ -3903,6 +4091,108 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>Polyline</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polylines)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polylines) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Line should have two points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;lid&quot; value in line %1. &quot;lid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/languages/iRIC_hu_HU.ts
+++ b/languages/iRIC_hu_HU.ts
@@ -3323,6 +3323,14 @@ p, li { white-space: pre-wrap; }
         <source>Finish Defining Point</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeoDataPointColorSimpleSettingDialog</name>

--- a/languages/iRIC_id_ID.ts
+++ b/languages/iRIC_id_ID.ts
@@ -2526,6 +2526,84 @@ p, li { white-space: pre-wrap; }
     </message>
 </context>
 <context>
+    <name>GeoDataPointGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPointGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Points)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Points) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPointGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>
@@ -3597,6 +3675,116 @@ p, li { white-space: pre-wrap; }
     </message>
 </context>
 <context>
+    <name>GeoDataPolygonGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Some polygon in this polygon group has holes, but holes are not exported to CSV file. If you want to export holes, please export to ESRI Shapefile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolygonGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polygons)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polygons) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Polygon should have three points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;pid&quot; value in line %1. &quot;pid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolygonGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>
@@ -3903,6 +4091,108 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>Polyline</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polylines)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polylines) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Line should have two points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;lid&quot; value in line %1. &quot;lid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/languages/iRIC_id_ID.ts
+++ b/languages/iRIC_id_ID.ts
@@ -3323,6 +3323,14 @@ p, li { white-space: pre-wrap; }
         <source>Finish Defining Point</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeoDataPointColorSimpleSettingDialog</name>

--- a/languages/iRIC_is_IS.ts
+++ b/languages/iRIC_is_IS.ts
@@ -2526,6 +2526,84 @@ p, li { white-space: pre-wrap; }
     </message>
 </context>
 <context>
+    <name>GeoDataPointGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPointGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Points)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Points) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPointGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>
@@ -3597,6 +3675,116 @@ p, li { white-space: pre-wrap; }
     </message>
 </context>
 <context>
+    <name>GeoDataPolygonGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Some polygon in this polygon group has holes, but holes are not exported to CSV file. If you want to export holes, please export to ESRI Shapefile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolygonGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polygons)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polygons) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Polygon should have three points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;pid&quot; value in line %1. &quot;pid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolygonGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>
@@ -3903,6 +4091,108 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>Polyline</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polylines)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polylines) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Line should have two points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;lid&quot; value in line %1. &quot;lid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/languages/iRIC_is_IS.ts
+++ b/languages/iRIC_is_IS.ts
@@ -3323,6 +3323,14 @@ p, li { white-space: pre-wrap; }
         <source>Finish Defining Point</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeoDataPointColorSimpleSettingDialog</name>

--- a/languages/iRIC_it_IT.ts
+++ b/languages/iRIC_it_IT.ts
@@ -2526,6 +2526,84 @@ p, li { white-space: pre-wrap; }
     </message>
 </context>
 <context>
+    <name>GeoDataPointGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPointGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Points)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Points) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPointGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>
@@ -3597,6 +3675,116 @@ p, li { white-space: pre-wrap; }
     </message>
 </context>
 <context>
+    <name>GeoDataPolygonGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Some polygon in this polygon group has holes, but holes are not exported to CSV file. If you want to export holes, please export to ESRI Shapefile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolygonGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polygons)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polygons) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Polygon should have three points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;pid&quot; value in line %1. &quot;pid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolygonGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>
@@ -3903,6 +4091,108 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>Polyline</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polylines)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polylines) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Line should have two points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;lid&quot; value in line %1. &quot;lid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/languages/iRIC_it_IT.ts
+++ b/languages/iRIC_it_IT.ts
@@ -3323,6 +3323,14 @@ p, li { white-space: pre-wrap; }
         <source>Finish Defining Point</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeoDataPointColorSimpleSettingDialog</name>

--- a/languages/iRIC_ja_JP.ts
+++ b/languages/iRIC_ja_JP.ts
@@ -3008,6 +3008,84 @@ p, li { white-space: pre-wrap; }
     </message>
 </context>
 <context>
+    <name>GeoDataPointGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation>CSV ファイル</translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation>エラー</translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation>%1 へのエクスポートでエラーが発生しました。</translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation>CSV ファイル (*.csv)</translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPointGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Points)</source>
+        <translation>CSV ファイル (点)</translation>
+    </message>
+    <message>
+        <source>CSV file (Points) (*.csv)</source>
+        <translation>CSV ファイル (点) (*.csv)</translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation>エラー</translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation>%1 を開けませんでした。</translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation>ヘッダ行の読み込み中にエラーが発生しました。UTF-8 エンコーディングで保存されているか確認してください。</translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 3 columns at least.</source>
+        <translation>ヘッダ行の読み込み中にエラーが発生しました。ヘッダには3列以上データがなくてはいけません。</translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 4 columns at least.</source>
+        <translation>ヘッダ行の読み込み中にエラーが発生しました。ヘッダには4列以上データがなくてはいけません。</translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation>ヘッダ行の読み込み中にエラーが発生しました。%1 列目の値は &quot;%2&quot; のはずですが、&quot;%3&quot; が指定されています。</translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation>%1行目の読み込み中にエラーが発生しました。UTF-8 エンコーディングで保存されているか確認してください。</translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 3 columns at least.</source>
+        <translation>%1行目の読み込み中にエラーが発生しました。3列以上データがなくてはいけません。</translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 4 columns at least.</source>
+        <translation>%1行目の読み込み中にエラーが発生しました。4列以上データがなくてはいけません。</translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation>%1行目の &quot;x&quot; の読み込み中にエラーが発生しました。 &quot;x&quot; は実数値でなくてはいけませんが、 &quot;%2&quot; が指定されました。</translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation>%1行目の &quot;y&quot; の読み込み中にエラーが発生しました。 &quot;y&quot; は実数値でなくてはいけませんが、 &quot;%2&quot; が指定されました。</translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation>%1行目の &quot;value&quot; の読み込み中にエラーが発生しました。 &quot;value&quot; は実数値でなくてはいけませんが、 &quot;%2&quot; が指定されました。</translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPointGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>
@@ -4869,6 +4947,116 @@ p, li { white-space: pre-wrap; }
     </message>
 </context>
 <context>
+    <name>GeoDataPolygonGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation>CSV ファイル</translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation>エラー</translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation>%1 へのエクスポートでエラーが発生しました。</translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation>警告</translation>
+    </message>
+    <message>
+        <source>Some polygon in this polygon group has holes, but holes are not exported to CSV file. If you want to export holes, please export to ESRI Shapefile.</source>
+        <translation>ポリゴンに、穴が空いているものがありますが、 CSVファイルには穴の情報をエクスポートできません。穴の情報をエクスポートしたい場合、ESRIシェープファイルにエクスポートしてください。</translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation>CSV ファイル (*.csv)</translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolygonGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polygons)</source>
+        <translation>CSV ファイル (ポリゴン)</translation>
+    </message>
+    <message>
+        <source>CSV file (Polygons) (*.csv)</source>
+        <translation>CSV ファイル (ポリゴン) (*.csv)</translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation>エラー</translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation>%1 を開けませんでした。</translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation>ヘッダ行の読み込み中にエラーが発生しました。UTF-8 エンコーディングで保存されているか確認してください。</translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation>ヘッダ行の読み込み中にエラーが発生しました。ヘッダには5列以上データがなくてはいけません。</translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation>ヘッダ行の読み込み中にエラーが発生しました。ヘッダには5列以上データがなくてはいけません。</translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation>ヘッダ行の読み込み中にエラーが発生しました。ヘッダには6列以上データがなくてはいけません。</translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation>%1行目の読み込み中にエラーが発生しました。データがありません。</translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Polygon should have three points at least.</source>
+        <translation>ヘッダ行の読み込み中にエラーが発生しました。%1 列目の値は &quot;%2&quot; のはずですが、&quot;%3&quot; が指定されています。</translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation>%1行目の読み込み中にエラーが発生しました。UTF-8 エンコーディングで保存されているか確認してください。</translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation>%1行目の読み込み中にエラーが発生しました。5列以上データがなくてはいけません。</translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation>%1行目の読み込み中にエラーが発生しました。6列以上データがなくてはいけません。</translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;pid&quot; value in line %1. &quot;pid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation>%1行目の &quot;pid&quot; の読み込み中にエラーが発生しました。 &quot;pid&quot; は整数値でなくてはいけませんが、 &quot;%2&quot; が指定されました。</translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation>%1行目の &quot;vid&quot; の読み込み中にエラーが発生しました。 &quot;vid&quot; は整数値でなくてはいけませんが、 &quot;%2&quot; が指定されました。</translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation>%1行目の &quot;x&quot; の読み込み中にエラーが発生しました。 &quot;x&quot; は実数値でなくてはいけませんが、 &quot;%2&quot; が指定されました。</translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation>%1行目の &quot;y&quot; の読み込み中にエラーが発生しました。 &quot;y&quot; は実数値でなくてはいけませんが、 &quot;%2&quot; が指定されました。</translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation>%1行目の &quot;value&quot; の読み込み中にエラーが発生しました。 &quot;value&quot; は実数値でなくてはいけませんが、 &quot;%2&quot; が指定されました。</translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation>%1行目の読み込み中にエラーが発生しました。 &quot;name&quot; は同じ &quot;pid&quot; の行で共通である必要があります。</translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation>%1行目の読み込み中にエラーが発生しました。 &quot;value&quot; は同じ &quot;pid&quot; の行で共通である必要があります。</translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolygonGroupMergeSettingDialog</name>
     <message>
         <source>Select data to merge</source>
@@ -5817,6 +6005,108 @@ p, li { white-space: pre-wrap; }
     <message>
         <source>Polyline</source>
         <translation>折れ線</translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation>CSV ファイル</translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation>エラー</translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation>%1 へのエクスポートでエラーが発生しました。</translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation>CSV ファイル (*.csv)</translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polylines)</source>
+        <translation>CSV ファイル (線)</translation>
+    </message>
+    <message>
+        <source>CSV file (Polylines) (*.csv)</source>
+        <translation>CSV ファイル (線) (*.csv)</translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation>エラー</translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation>%1 を開けませんでした。</translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation>ヘッダ行の読み込み中にエラーが発生しました。UTF-8 エンコーディングで保存されているか確認してください。</translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation>ヘッダ行の読み込み中にエラーが発生しました。ヘッダには5列以上データがなくてはいけません。</translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation>ヘッダ行の読み込み中にエラーが発生しました。ヘッダには6列以上データがなくてはいけません。</translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation>ヘッダ行の読み込み中にエラーが発生しました。%1 列目の値は &quot;%2&quot; のはずですが、&quot;%3&quot; が指定されています。</translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation>%1行目の読み込み中にエラーが発生しました。データがありません。</translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Line should have two points at least.</source>
+        <translation>%1行目の読み込み中にエラーが発生しました。線には最低限点が2つなくてはいけません。</translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation>%1行目の読み込み中にエラーが発生しました。UTF-8 エンコーディングで保存されているか確認してください。</translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation>%1行目の読み込み中にエラーが発生しました。5列以上データがなくてはいけません。</translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation>%1行目の読み込み中にエラーが発生しました。6列以上データがなくてはいけません。</translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;lid&quot; value in line %1. &quot;lid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation>%1行目の &quot;lid&quot; の読み込み中にエラーが発生しました。 &quot;lid&quot; は整数値でなくてはいけませんが、 &quot;%2&quot; が指定されました。</translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation>%1行目の &quot;vid&quot; の読み込み中にエラーが発生しました。 &quot;vid&quot; は整数値でなくてはいけませんが、 &quot;%2&quot; が指定されました。</translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation>%1行目の &quot;x&quot; の読み込み中にエラーが発生しました。 &quot;x&quot; は実数値でなくてはいけませんが、 &quot;%2&quot; が指定されました。</translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation>%1行目の &quot;y&quot; の読み込み中にエラーが発生しました。 &quot;y&quot; は実数値でなくてはいけませんが、 &quot;%2&quot; が指定されました。</translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation>%1行目の &quot;value&quot; の読み込み中にエラーが発生しました。 &quot;value&quot; は実数値でなくてはいけませんが、 &quot;%2&quot; が指定されました。</translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation>%1行目の読み込み中にエラーが発生しました。 &quot;name&quot; は同じ &quot;lid&quot; の行で共通である必要があります。</translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation>%1行目の読み込み中にエラーが発生しました。 &quot;value&quot; は同じ &quot;lid&quot; の行で共通である必要があります。</translation>
     </message>
 </context>
 <context>

--- a/languages/iRIC_ja_JP.ts
+++ b/languages/iRIC_ja_JP.ts
@@ -4418,6 +4418,14 @@ p, li { white-space: pre-wrap; }
         <source>Point name and value change</source>
         <translation type="vanished">点の名前と値の変更</translation>
     </message>
+    <message>
+        <source>Point Coordinates</source>
+        <translation>点の座標</translation>
+    </message>
+    <message>
+        <source>Edit Point Coordinates</source>
+        <translation>点の座標の編集</translation>
+    </message>
 </context>
 <context>
     <name>GeoDataPointColorSimpleSettingDialog</name>

--- a/languages/iRIC_ko_KR.ts
+++ b/languages/iRIC_ko_KR.ts
@@ -2526,6 +2526,84 @@ p, li { white-space: pre-wrap; }
     </message>
 </context>
 <context>
+    <name>GeoDataPointGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPointGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Points)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Points) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPointGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>
@@ -3597,6 +3675,116 @@ p, li { white-space: pre-wrap; }
     </message>
 </context>
 <context>
+    <name>GeoDataPolygonGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Some polygon in this polygon group has holes, but holes are not exported to CSV file. If you want to export holes, please export to ESRI Shapefile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolygonGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polygons)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polygons) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Polygon should have three points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;pid&quot; value in line %1. &quot;pid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolygonGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>
@@ -3903,6 +4091,108 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>Polyline</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polylines)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polylines) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Line should have two points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;lid&quot; value in line %1. &quot;lid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/languages/iRIC_ko_KR.ts
+++ b/languages/iRIC_ko_KR.ts
@@ -3323,6 +3323,14 @@ p, li { white-space: pre-wrap; }
         <source>Finish Defining Point</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeoDataPointColorSimpleSettingDialog</name>

--- a/languages/iRIC_ky_KG.ts
+++ b/languages/iRIC_ky_KG.ts
@@ -2526,6 +2526,84 @@ p, li { white-space: pre-wrap; }
     </message>
 </context>
 <context>
+    <name>GeoDataPointGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPointGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Points)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Points) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPointGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>
@@ -3597,6 +3675,116 @@ p, li { white-space: pre-wrap; }
     </message>
 </context>
 <context>
+    <name>GeoDataPolygonGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Some polygon in this polygon group has holes, but holes are not exported to CSV file. If you want to export holes, please export to ESRI Shapefile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolygonGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polygons)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polygons) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Polygon should have three points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;pid&quot; value in line %1. &quot;pid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolygonGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>
@@ -3903,6 +4091,108 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>Polyline</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polylines)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polylines) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Line should have two points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;lid&quot; value in line %1. &quot;lid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/languages/iRIC_ky_KG.ts
+++ b/languages/iRIC_ky_KG.ts
@@ -3323,6 +3323,14 @@ p, li { white-space: pre-wrap; }
         <source>Finish Defining Point</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeoDataPointColorSimpleSettingDialog</name>

--- a/languages/iRIC_lt_LT.ts
+++ b/languages/iRIC_lt_LT.ts
@@ -2526,6 +2526,84 @@ p, li { white-space: pre-wrap; }
     </message>
 </context>
 <context>
+    <name>GeoDataPointGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPointGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Points)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Points) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPointGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>
@@ -3597,6 +3675,116 @@ p, li { white-space: pre-wrap; }
     </message>
 </context>
 <context>
+    <name>GeoDataPolygonGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Some polygon in this polygon group has holes, but holes are not exported to CSV file. If you want to export holes, please export to ESRI Shapefile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolygonGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polygons)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polygons) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Polygon should have three points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;pid&quot; value in line %1. &quot;pid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolygonGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>
@@ -3903,6 +4091,108 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>Polyline</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polylines)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polylines) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Line should have two points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;lid&quot; value in line %1. &quot;lid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/languages/iRIC_lt_LT.ts
+++ b/languages/iRIC_lt_LT.ts
@@ -3323,6 +3323,14 @@ p, li { white-space: pre-wrap; }
         <source>Finish Defining Point</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeoDataPointColorSimpleSettingDialog</name>

--- a/languages/iRIC_lv_LV.ts
+++ b/languages/iRIC_lv_LV.ts
@@ -2526,6 +2526,84 @@ p, li { white-space: pre-wrap; }
     </message>
 </context>
 <context>
+    <name>GeoDataPointGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPointGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Points)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Points) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPointGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>
@@ -3597,6 +3675,116 @@ p, li { white-space: pre-wrap; }
     </message>
 </context>
 <context>
+    <name>GeoDataPolygonGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Some polygon in this polygon group has holes, but holes are not exported to CSV file. If you want to export holes, please export to ESRI Shapefile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolygonGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polygons)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polygons) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Polygon should have three points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;pid&quot; value in line %1. &quot;pid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolygonGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>
@@ -3903,6 +4091,108 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>Polyline</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polylines)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polylines) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Line should have two points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;lid&quot; value in line %1. &quot;lid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/languages/iRIC_lv_LV.ts
+++ b/languages/iRIC_lv_LV.ts
@@ -3323,6 +3323,14 @@ p, li { white-space: pre-wrap; }
         <source>Finish Defining Point</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeoDataPointColorSimpleSettingDialog</name>

--- a/languages/iRIC_nb_NO.ts
+++ b/languages/iRIC_nb_NO.ts
@@ -2526,6 +2526,84 @@ p, li { white-space: pre-wrap; }
     </message>
 </context>
 <context>
+    <name>GeoDataPointGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPointGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Points)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Points) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPointGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>
@@ -3597,6 +3675,116 @@ p, li { white-space: pre-wrap; }
     </message>
 </context>
 <context>
+    <name>GeoDataPolygonGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Some polygon in this polygon group has holes, but holes are not exported to CSV file. If you want to export holes, please export to ESRI Shapefile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolygonGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polygons)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polygons) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Polygon should have three points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;pid&quot; value in line %1. &quot;pid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolygonGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>
@@ -3903,6 +4091,108 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>Polyline</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polylines)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polylines) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Line should have two points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;lid&quot; value in line %1. &quot;lid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/languages/iRIC_nb_NO.ts
+++ b/languages/iRIC_nb_NO.ts
@@ -3323,6 +3323,14 @@ p, li { white-space: pre-wrap; }
         <source>Finish Defining Point</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeoDataPointColorSimpleSettingDialog</name>

--- a/languages/iRIC_nl_NL.ts
+++ b/languages/iRIC_nl_NL.ts
@@ -2526,6 +2526,84 @@ p, li { white-space: pre-wrap; }
     </message>
 </context>
 <context>
+    <name>GeoDataPointGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPointGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Points)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Points) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPointGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>
@@ -3597,6 +3675,116 @@ p, li { white-space: pre-wrap; }
     </message>
 </context>
 <context>
+    <name>GeoDataPolygonGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Some polygon in this polygon group has holes, but holes are not exported to CSV file. If you want to export holes, please export to ESRI Shapefile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolygonGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polygons)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polygons) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Polygon should have three points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;pid&quot; value in line %1. &quot;pid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolygonGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>
@@ -3903,6 +4091,108 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>Polyline</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polylines)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polylines) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Line should have two points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;lid&quot; value in line %1. &quot;lid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/languages/iRIC_nl_NL.ts
+++ b/languages/iRIC_nl_NL.ts
@@ -3323,6 +3323,14 @@ p, li { white-space: pre-wrap; }
         <source>Finish Defining Point</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeoDataPointColorSimpleSettingDialog</name>

--- a/languages/iRIC_pl_PL.ts
+++ b/languages/iRIC_pl_PL.ts
@@ -2526,6 +2526,84 @@ p, li { white-space: pre-wrap; }
     </message>
 </context>
 <context>
+    <name>GeoDataPointGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPointGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Points)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Points) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPointGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>
@@ -3597,6 +3675,116 @@ p, li { white-space: pre-wrap; }
     </message>
 </context>
 <context>
+    <name>GeoDataPolygonGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Some polygon in this polygon group has holes, but holes are not exported to CSV file. If you want to export holes, please export to ESRI Shapefile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolygonGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polygons)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polygons) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Polygon should have three points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;pid&quot; value in line %1. &quot;pid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolygonGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>
@@ -3903,6 +4091,108 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>Polyline</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polylines)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polylines) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Line should have two points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;lid&quot; value in line %1. &quot;lid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/languages/iRIC_pl_PL.ts
+++ b/languages/iRIC_pl_PL.ts
@@ -3323,6 +3323,14 @@ p, li { white-space: pre-wrap; }
         <source>Finish Defining Point</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeoDataPointColorSimpleSettingDialog</name>

--- a/languages/iRIC_pt_BR.ts
+++ b/languages/iRIC_pt_BR.ts
@@ -2538,6 +2538,84 @@ p, li { white-space: pre-wrap; }
     </message>
 </context>
 <context>
+    <name>GeoDataPointGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPointGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Points)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Points) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPointGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>
@@ -3672,6 +3750,116 @@ p, li { white-space: pre-wrap; }
     </message>
 </context>
 <context>
+    <name>GeoDataPolygonGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished">Erro</translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation type="unfinished">Atencao</translation>
+    </message>
+    <message>
+        <source>Some polygon in this polygon group has holes, but holes are not exported to CSV file. If you want to export holes, please export to ESRI Shapefile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolygonGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polygons)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polygons) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished">Erro</translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Polygon should have three points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;pid&quot; value in line %1. &quot;pid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolygonGroupMergeSettingDialog</name>
     <message>
         <source>Select data to merge</source>
@@ -4084,6 +4272,108 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>Polyline</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polylines)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polylines) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Line should have two points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;lid&quot; value in line %1. &quot;lid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/languages/iRIC_pt_BR.ts
+++ b/languages/iRIC_pt_BR.ts
@@ -3335,6 +3335,14 @@ p, li { white-space: pre-wrap; }
         <source>Finish Defining Point</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeoDataPointColorSimpleSettingDialog</name>

--- a/languages/iRIC_pt_PT.ts
+++ b/languages/iRIC_pt_PT.ts
@@ -2526,6 +2526,84 @@ p, li { white-space: pre-wrap; }
     </message>
 </context>
 <context>
+    <name>GeoDataPointGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPointGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Points)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Points) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPointGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>
@@ -3597,6 +3675,116 @@ p, li { white-space: pre-wrap; }
     </message>
 </context>
 <context>
+    <name>GeoDataPolygonGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Some polygon in this polygon group has holes, but holes are not exported to CSV file. If you want to export holes, please export to ESRI Shapefile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolygonGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polygons)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polygons) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Polygon should have three points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;pid&quot; value in line %1. &quot;pid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolygonGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>
@@ -3903,6 +4091,108 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>Polyline</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polylines)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polylines) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Line should have two points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;lid&quot; value in line %1. &quot;lid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/languages/iRIC_pt_PT.ts
+++ b/languages/iRIC_pt_PT.ts
@@ -3323,6 +3323,14 @@ p, li { white-space: pre-wrap; }
         <source>Finish Defining Point</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeoDataPointColorSimpleSettingDialog</name>

--- a/languages/iRIC_ro_RO.ts
+++ b/languages/iRIC_ro_RO.ts
@@ -2526,6 +2526,84 @@ p, li { white-space: pre-wrap; }
     </message>
 </context>
 <context>
+    <name>GeoDataPointGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPointGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Points)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Points) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPointGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>
@@ -3597,6 +3675,116 @@ p, li { white-space: pre-wrap; }
     </message>
 </context>
 <context>
+    <name>GeoDataPolygonGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Some polygon in this polygon group has holes, but holes are not exported to CSV file. If you want to export holes, please export to ESRI Shapefile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolygonGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polygons)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polygons) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Polygon should have three points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;pid&quot; value in line %1. &quot;pid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolygonGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>
@@ -3903,6 +4091,108 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>Polyline</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polylines)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polylines) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Line should have two points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;lid&quot; value in line %1. &quot;lid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/languages/iRIC_ro_RO.ts
+++ b/languages/iRIC_ro_RO.ts
@@ -3323,6 +3323,14 @@ p, li { white-space: pre-wrap; }
         <source>Finish Defining Point</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeoDataPointColorSimpleSettingDialog</name>

--- a/languages/iRIC_ru_RU.ts
+++ b/languages/iRIC_ru_RU.ts
@@ -2526,6 +2526,84 @@ p, li { white-space: pre-wrap; }
     </message>
 </context>
 <context>
+    <name>GeoDataPointGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPointGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Points)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Points) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPointGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>
@@ -3597,6 +3675,116 @@ p, li { white-space: pre-wrap; }
     </message>
 </context>
 <context>
+    <name>GeoDataPolygonGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Some polygon in this polygon group has holes, but holes are not exported to CSV file. If you want to export holes, please export to ESRI Shapefile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolygonGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polygons)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polygons) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Polygon should have three points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;pid&quot; value in line %1. &quot;pid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolygonGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>
@@ -3903,6 +4091,108 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>Polyline</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polylines)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polylines) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Line should have two points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;lid&quot; value in line %1. &quot;lid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/languages/iRIC_ru_RU.ts
+++ b/languages/iRIC_ru_RU.ts
@@ -3323,6 +3323,14 @@ p, li { white-space: pre-wrap; }
         <source>Finish Defining Point</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeoDataPointColorSimpleSettingDialog</name>

--- a/languages/iRIC_sl_SI.ts
+++ b/languages/iRIC_sl_SI.ts
@@ -2526,6 +2526,84 @@ p, li { white-space: pre-wrap; }
     </message>
 </context>
 <context>
+    <name>GeoDataPointGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPointGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Points)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Points) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPointGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>
@@ -3597,6 +3675,116 @@ p, li { white-space: pre-wrap; }
     </message>
 </context>
 <context>
+    <name>GeoDataPolygonGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Some polygon in this polygon group has holes, but holes are not exported to CSV file. If you want to export holes, please export to ESRI Shapefile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolygonGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polygons)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polygons) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Polygon should have three points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;pid&quot; value in line %1. &quot;pid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolygonGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>
@@ -3903,6 +4091,108 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>Polyline</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polylines)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polylines) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Line should have two points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;lid&quot; value in line %1. &quot;lid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/languages/iRIC_sl_SI.ts
+++ b/languages/iRIC_sl_SI.ts
@@ -3323,6 +3323,14 @@ p, li { white-space: pre-wrap; }
         <source>Finish Defining Point</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeoDataPointColorSimpleSettingDialog</name>

--- a/languages/iRIC_sv_SE.ts
+++ b/languages/iRIC_sv_SE.ts
@@ -2526,6 +2526,84 @@ p, li { white-space: pre-wrap; }
     </message>
 </context>
 <context>
+    <name>GeoDataPointGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPointGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Points)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Points) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPointGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>
@@ -3597,6 +3675,116 @@ p, li { white-space: pre-wrap; }
     </message>
 </context>
 <context>
+    <name>GeoDataPolygonGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Some polygon in this polygon group has holes, but holes are not exported to CSV file. If you want to export holes, please export to ESRI Shapefile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolygonGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polygons)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polygons) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Polygon should have three points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;pid&quot; value in line %1. &quot;pid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolygonGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>
@@ -3903,6 +4091,108 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>Polyline</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polylines)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polylines) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Line should have two points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;lid&quot; value in line %1. &quot;lid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/languages/iRIC_sv_SE.ts
+++ b/languages/iRIC_sv_SE.ts
@@ -3323,6 +3323,14 @@ p, li { white-space: pre-wrap; }
         <source>Finish Defining Point</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeoDataPointColorSimpleSettingDialog</name>

--- a/languages/iRIC_th_TH.ts
+++ b/languages/iRIC_th_TH.ts
@@ -2526,6 +2526,84 @@ p, li { white-space: pre-wrap; }
     </message>
 </context>
 <context>
+    <name>GeoDataPointGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPointGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Points)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Points) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPointGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>
@@ -3597,6 +3675,116 @@ p, li { white-space: pre-wrap; }
     </message>
 </context>
 <context>
+    <name>GeoDataPolygonGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Some polygon in this polygon group has holes, but holes are not exported to CSV file. If you want to export holes, please export to ESRI Shapefile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolygonGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polygons)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polygons) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Polygon should have three points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;pid&quot; value in line %1. &quot;pid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolygonGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>
@@ -3903,6 +4091,108 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>Polyline</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polylines)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polylines) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Line should have two points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;lid&quot; value in line %1. &quot;lid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/languages/iRIC_th_TH.ts
+++ b/languages/iRIC_th_TH.ts
@@ -3323,6 +3323,14 @@ p, li { white-space: pre-wrap; }
         <source>Finish Defining Point</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeoDataPointColorSimpleSettingDialog</name>

--- a/languages/iRIC_tr_TR.ts
+++ b/languages/iRIC_tr_TR.ts
@@ -2526,6 +2526,84 @@ p, li { white-space: pre-wrap; }
     </message>
 </context>
 <context>
+    <name>GeoDataPointGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPointGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Points)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Points) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPointGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>
@@ -3597,6 +3675,116 @@ p, li { white-space: pre-wrap; }
     </message>
 </context>
 <context>
+    <name>GeoDataPolygonGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Some polygon in this polygon group has holes, but holes are not exported to CSV file. If you want to export holes, please export to ESRI Shapefile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolygonGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polygons)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polygons) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Polygon should have three points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;pid&quot; value in line %1. &quot;pid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolygonGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>
@@ -3903,6 +4091,108 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>Polyline</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polylines)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polylines) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Line should have two points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;lid&quot; value in line %1. &quot;lid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/languages/iRIC_tr_TR.ts
+++ b/languages/iRIC_tr_TR.ts
@@ -3323,6 +3323,14 @@ p, li { white-space: pre-wrap; }
         <source>Finish Defining Point</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeoDataPointColorSimpleSettingDialog</name>

--- a/languages/iRIC_uk_UA.ts
+++ b/languages/iRIC_uk_UA.ts
@@ -2526,6 +2526,84 @@ p, li { white-space: pre-wrap; }
     </message>
 </context>
 <context>
+    <name>GeoDataPointGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPointGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Points)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Points) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPointGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>
@@ -3597,6 +3675,116 @@ p, li { white-space: pre-wrap; }
     </message>
 </context>
 <context>
+    <name>GeoDataPolygonGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Some polygon in this polygon group has holes, but holes are not exported to CSV file. If you want to export holes, please export to ESRI Shapefile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolygonGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polygons)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polygons) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Polygon should have three points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;pid&quot; value in line %1. &quot;pid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolygonGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>
@@ -3903,6 +4091,108 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>Polyline</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polylines)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polylines) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Line should have two points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;lid&quot; value in line %1. &quot;lid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/languages/iRIC_uk_UA.ts
+++ b/languages/iRIC_uk_UA.ts
@@ -3323,6 +3323,14 @@ p, li { white-space: pre-wrap; }
         <source>Finish Defining Point</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeoDataPointColorSimpleSettingDialog</name>

--- a/languages/iRIC_vi_VN.ts
+++ b/languages/iRIC_vi_VN.ts
@@ -2526,6 +2526,84 @@ p, li { white-space: pre-wrap; }
     </message>
 </context>
 <context>
+    <name>GeoDataPointGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPointGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Points)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Points) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPointGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>
@@ -3597,6 +3675,116 @@ p, li { white-space: pre-wrap; }
     </message>
 </context>
 <context>
+    <name>GeoDataPolygonGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Some polygon in this polygon group has holes, but holes are not exported to CSV file. If you want to export holes, please export to ESRI Shapefile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolygonGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polygons)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polygons) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Polygon should have three points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;pid&quot; value in line %1. &quot;pid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolygonGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>
@@ -3903,6 +4091,108 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>Polyline</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polylines)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polylines) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Line should have two points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;lid&quot; value in line %1. &quot;lid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/languages/iRIC_vi_VN.ts
+++ b/languages/iRIC_vi_VN.ts
@@ -3323,6 +3323,14 @@ p, li { white-space: pre-wrap; }
         <source>Finish Defining Point</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeoDataPointColorSimpleSettingDialog</name>

--- a/languages/iRIC_zh_CN.ts
+++ b/languages/iRIC_zh_CN.ts
@@ -3405,6 +3405,14 @@ p, li { white-space: pre-wrap; }
         <source>Finish Defining Point</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeoDataPointColorSimpleSettingDialog</name>

--- a/languages/iRIC_zh_CN.ts
+++ b/languages/iRIC_zh_CN.ts
@@ -2608,6 +2608,84 @@ p, li { white-space: pre-wrap; }
     </message>
 </context>
 <context>
+    <name>GeoDataPointGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPointGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Points)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Points) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPointGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>
@@ -3757,6 +3835,116 @@ p, li { white-space: pre-wrap; }
     </message>
 </context>
 <context>
+    <name>GeoDataPolygonGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished">错误</translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation type="unfinished">警告</translation>
+    </message>
+    <message>
+        <source>Some polygon in this polygon group has holes, but holes are not exported to CSV file. If you want to export holes, please export to ESRI Shapefile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolygonGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polygons)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polygons) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished">错误</translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Polygon should have three points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;pid&quot; value in line %1. &quot;pid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolygonGroupMergeSettingDialog</name>
     <message>
         <source>Select data to merge</source>
@@ -4200,6 +4388,108 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>Polyline</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polylines)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polylines) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Line should have two points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;lid&quot; value in line %1. &quot;lid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/languages/iRIC_zh_TW.ts
+++ b/languages/iRIC_zh_TW.ts
@@ -2526,6 +2526,84 @@ p, li { white-space: pre-wrap; }
     </message>
 </context>
 <context>
+    <name>GeoDataPointGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPointGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Points)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Points) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPointGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>
@@ -3597,6 +3675,116 @@ p, li { white-space: pre-wrap; }
     </message>
 </context>
 <context>
+    <name>GeoDataPolygonGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Some polygon in this polygon group has holes, but holes are not exported to CSV file. If you want to export holes, please export to ESRI Shapefile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolygonGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polygons)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polygons) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Polygon should have three points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;pid&quot; value in line %1. &quot;pid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolygonGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>
@@ -3903,6 +4091,108 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>Polyline</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polylines)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polylines) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Line should have two points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;lid&quot; value in line %1. &quot;lid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/languages/iRIC_zh_TW.ts
+++ b/languages/iRIC_zh_TW.ts
@@ -3323,6 +3323,14 @@ p, li { white-space: pre-wrap; }
         <source>Finish Defining Point</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeoDataPointColorSimpleSettingDialog</name>

--- a/languages/iricGdPointGroup_ar_EG.ts
+++ b/languages/iricGdPointGroup_ar_EG.ts
@@ -36,6 +36,84 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPointGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPointGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Points)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Points) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPointGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/languages/iricGdPointGroup_bg_BG.ts
+++ b/languages/iricGdPointGroup_bg_BG.ts
@@ -36,6 +36,84 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPointGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPointGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Points)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Points) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPointGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/languages/iricGdPointGroup_bs_BA.ts
+++ b/languages/iricGdPointGroup_bs_BA.ts
@@ -36,6 +36,84 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPointGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPointGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Points)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Points) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPointGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/languages/iricGdPointGroup_ca_ES.ts
+++ b/languages/iricGdPointGroup_ca_ES.ts
@@ -36,6 +36,84 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPointGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPointGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Points)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Points) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPointGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/languages/iricGdPointGroup_cs_CZ.ts
+++ b/languages/iricGdPointGroup_cs_CZ.ts
@@ -36,6 +36,84 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPointGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPointGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Points)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Points) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPointGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/languages/iricGdPointGroup_da_DK.ts
+++ b/languages/iricGdPointGroup_da_DK.ts
@@ -36,6 +36,84 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPointGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPointGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Points)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Points) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPointGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/languages/iricGdPointGroup_de_DE.ts
+++ b/languages/iricGdPointGroup_de_DE.ts
@@ -36,6 +36,84 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPointGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPointGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Points)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Points) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPointGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/languages/iricGdPointGroup_el_GR.ts
+++ b/languages/iricGdPointGroup_el_GR.ts
@@ -36,6 +36,84 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPointGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPointGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Points)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Points) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPointGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/languages/iricGdPointGroup_es_ES.ts
+++ b/languages/iricGdPointGroup_es_ES.ts
@@ -36,6 +36,84 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPointGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPointGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Points)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Points) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPointGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/languages/iricGdPointGroup_et_EE.ts
+++ b/languages/iricGdPointGroup_et_EE.ts
@@ -36,6 +36,84 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPointGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPointGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Points)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Points) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPointGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/languages/iricGdPointGroup_eu_ES.ts
+++ b/languages/iricGdPointGroup_eu_ES.ts
@@ -36,6 +36,84 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPointGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPointGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Points)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Points) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPointGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/languages/iricGdPointGroup_fi_FI.ts
+++ b/languages/iricGdPointGroup_fi_FI.ts
@@ -36,6 +36,84 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPointGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPointGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Points)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Points) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPointGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/languages/iricGdPointGroup_fr_FR.ts
+++ b/languages/iricGdPointGroup_fr_FR.ts
@@ -36,6 +36,84 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPointGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPointGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Points)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Points) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPointGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/languages/iricGdPointGroup_gl_ES.ts
+++ b/languages/iricGdPointGroup_gl_ES.ts
@@ -36,6 +36,84 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPointGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPointGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Points)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Points) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPointGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/languages/iricGdPointGroup_hi_IN.ts
+++ b/languages/iricGdPointGroup_hi_IN.ts
@@ -36,6 +36,84 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPointGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPointGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Points)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Points) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPointGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/languages/iricGdPointGroup_hu_HU.ts
+++ b/languages/iricGdPointGroup_hu_HU.ts
@@ -36,6 +36,84 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPointGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPointGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Points)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Points) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPointGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/languages/iricGdPointGroup_id_ID.ts
+++ b/languages/iricGdPointGroup_id_ID.ts
@@ -36,6 +36,84 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPointGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPointGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Points)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Points) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPointGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/languages/iricGdPointGroup_is_IS.ts
+++ b/languages/iricGdPointGroup_is_IS.ts
@@ -36,6 +36,84 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPointGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPointGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Points)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Points) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPointGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/languages/iricGdPointGroup_it_IT.ts
+++ b/languages/iricGdPointGroup_it_IT.ts
@@ -36,6 +36,84 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPointGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPointGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Points)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Points) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPointGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/languages/iricGdPointGroup_ja_JP.ts
+++ b/languages/iricGdPointGroup_ja_JP.ts
@@ -44,6 +44,84 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPointGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation>CSV ファイル</translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation>エラー</translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation>%1 へのエクスポートでエラーが発生しました。</translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation>CSV ファイル (*.csv)</translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPointGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Points)</source>
+        <translation>CSV ファイル (点)</translation>
+    </message>
+    <message>
+        <source>CSV file (Points) (*.csv)</source>
+        <translation>CSV ファイル (点) (*.csv)</translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation>エラー</translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation>%1 を開けませんでした。</translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation>ヘッダ行の読み込み中にエラーが発生しました。UTF-8 エンコーディングで保存されているか確認してください。</translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 3 columns at least.</source>
+        <translation>ヘッダ行の読み込み中にエラーが発生しました。ヘッダには3列以上データがなくてはいけません。</translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 4 columns at least.</source>
+        <translation>ヘッダ行の読み込み中にエラーが発生しました。ヘッダには4列以上データがなくてはいけません。</translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation>ヘッダ行の読み込み中にエラーが発生しました。%1 列目の値は &quot;%2&quot; のはずですが、&quot;%3&quot; が指定されています。</translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation>%1行目の読み込み中にエラーが発生しました。UTF-8 エンコーディングで保存されているか確認してください。</translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 3 columns at least.</source>
+        <translation>%1行目の読み込み中にエラーが発生しました。3列以上データがなくてはいけません。</translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 4 columns at least.</source>
+        <translation>%1行目の読み込み中にエラーが発生しました。4列以上データがなくてはいけません。</translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation>%1行目の &quot;x&quot; の読み込み中にエラーが発生しました。 &quot;x&quot; は実数値でなくてはいけませんが、 &quot;%2&quot; が指定されました。</translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation>%1行目の &quot;y&quot; の読み込み中にエラーが発生しました。 &quot;y&quot; は実数値でなくてはいけませんが、 &quot;%2&quot; が指定されました。</translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation>%1行目の &quot;value&quot; の読み込み中にエラーが発生しました。 &quot;value&quot; は実数値でなくてはいけませんが、 &quot;%2&quot; が指定されました。</translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPointGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/languages/iricGdPointGroup_ko_KR.ts
+++ b/languages/iricGdPointGroup_ko_KR.ts
@@ -36,6 +36,84 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPointGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPointGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Points)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Points) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPointGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/languages/iricGdPointGroup_ky_KG.ts
+++ b/languages/iricGdPointGroup_ky_KG.ts
@@ -36,6 +36,84 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPointGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPointGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Points)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Points) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPointGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/languages/iricGdPointGroup_lt_LT.ts
+++ b/languages/iricGdPointGroup_lt_LT.ts
@@ -36,6 +36,84 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPointGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPointGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Points)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Points) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPointGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/languages/iricGdPointGroup_lv_LV.ts
+++ b/languages/iricGdPointGroup_lv_LV.ts
@@ -36,6 +36,84 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPointGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPointGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Points)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Points) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPointGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/languages/iricGdPointGroup_nb_NO.ts
+++ b/languages/iricGdPointGroup_nb_NO.ts
@@ -36,6 +36,84 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPointGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPointGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Points)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Points) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPointGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/languages/iricGdPointGroup_nl_NL.ts
+++ b/languages/iricGdPointGroup_nl_NL.ts
@@ -36,6 +36,84 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPointGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPointGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Points)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Points) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPointGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/languages/iricGdPointGroup_pl_PL.ts
+++ b/languages/iricGdPointGroup_pl_PL.ts
@@ -36,6 +36,84 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPointGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPointGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Points)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Points) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPointGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/languages/iricGdPointGroup_pt_BR.ts
+++ b/languages/iricGdPointGroup_pt_BR.ts
@@ -36,6 +36,84 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPointGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPointGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Points)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Points) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPointGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/languages/iricGdPointGroup_pt_PT.ts
+++ b/languages/iricGdPointGroup_pt_PT.ts
@@ -36,6 +36,84 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPointGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPointGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Points)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Points) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPointGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/languages/iricGdPointGroup_ro_RO.ts
+++ b/languages/iricGdPointGroup_ro_RO.ts
@@ -36,6 +36,84 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPointGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPointGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Points)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Points) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPointGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/languages/iricGdPointGroup_ru_RU.ts
+++ b/languages/iricGdPointGroup_ru_RU.ts
@@ -36,6 +36,84 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPointGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPointGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Points)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Points) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPointGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/languages/iricGdPointGroup_sl_SI.ts
+++ b/languages/iricGdPointGroup_sl_SI.ts
@@ -36,6 +36,84 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPointGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPointGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Points)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Points) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPointGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/languages/iricGdPointGroup_sv_SE.ts
+++ b/languages/iricGdPointGroup_sv_SE.ts
@@ -36,6 +36,84 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPointGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPointGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Points)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Points) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPointGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/languages/iricGdPointGroup_th_TH.ts
+++ b/languages/iricGdPointGroup_th_TH.ts
@@ -36,6 +36,84 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPointGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPointGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Points)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Points) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPointGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/languages/iricGdPointGroup_tr_TR.ts
+++ b/languages/iricGdPointGroup_tr_TR.ts
@@ -36,6 +36,84 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPointGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPointGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Points)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Points) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPointGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/languages/iricGdPointGroup_uk_UA.ts
+++ b/languages/iricGdPointGroup_uk_UA.ts
@@ -36,6 +36,84 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPointGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPointGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Points)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Points) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPointGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/languages/iricGdPointGroup_vi_VN.ts
+++ b/languages/iricGdPointGroup_vi_VN.ts
@@ -36,6 +36,84 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPointGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPointGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Points)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Points) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPointGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/languages/iricGdPointGroup_zh_CN.ts
+++ b/languages/iricGdPointGroup_zh_CN.ts
@@ -36,6 +36,84 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPointGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPointGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Points)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Points) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPointGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/languages/iricGdPointGroup_zh_TW.ts
+++ b/languages/iricGdPointGroup_zh_TW.ts
@@ -36,6 +36,84 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPointGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPointGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Points)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Points) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPointGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/languages/iricGdPoint_ar_EG.ts
+++ b/languages/iricGdPoint_ar_EG.ts
@@ -31,6 +31,14 @@
         <source>Finish Defining Point</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeoDataPointColorSimpleSettingDialog</name>

--- a/languages/iricGdPoint_bg_BG.ts
+++ b/languages/iricGdPoint_bg_BG.ts
@@ -31,6 +31,14 @@
         <source>Finish Defining Point</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeoDataPointColorSimpleSettingDialog</name>

--- a/languages/iricGdPoint_bs_BA.ts
+++ b/languages/iricGdPoint_bs_BA.ts
@@ -31,6 +31,14 @@
         <source>Finish Defining Point</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeoDataPointColorSimpleSettingDialog</name>

--- a/languages/iricGdPoint_ca_ES.ts
+++ b/languages/iricGdPoint_ca_ES.ts
@@ -31,6 +31,14 @@
         <source>Finish Defining Point</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeoDataPointColorSimpleSettingDialog</name>

--- a/languages/iricGdPoint_cs_CZ.ts
+++ b/languages/iricGdPoint_cs_CZ.ts
@@ -31,6 +31,14 @@
         <source>Finish Defining Point</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeoDataPointColorSimpleSettingDialog</name>

--- a/languages/iricGdPoint_da_DK.ts
+++ b/languages/iricGdPoint_da_DK.ts
@@ -31,6 +31,14 @@
         <source>Finish Defining Point</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeoDataPointColorSimpleSettingDialog</name>

--- a/languages/iricGdPoint_de_DE.ts
+++ b/languages/iricGdPoint_de_DE.ts
@@ -31,6 +31,14 @@
         <source>Finish Defining Point</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeoDataPointColorSimpleSettingDialog</name>

--- a/languages/iricGdPoint_el_GR.ts
+++ b/languages/iricGdPoint_el_GR.ts
@@ -31,6 +31,14 @@
         <source>Finish Defining Point</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeoDataPointColorSimpleSettingDialog</name>

--- a/languages/iricGdPoint_es_ES.ts
+++ b/languages/iricGdPoint_es_ES.ts
@@ -31,6 +31,14 @@
         <source>Finish Defining Point</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeoDataPointColorSimpleSettingDialog</name>

--- a/languages/iricGdPoint_et_EE.ts
+++ b/languages/iricGdPoint_et_EE.ts
@@ -31,6 +31,14 @@
         <source>Finish Defining Point</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeoDataPointColorSimpleSettingDialog</name>

--- a/languages/iricGdPoint_eu_ES.ts
+++ b/languages/iricGdPoint_eu_ES.ts
@@ -31,6 +31,14 @@
         <source>Finish Defining Point</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeoDataPointColorSimpleSettingDialog</name>

--- a/languages/iricGdPoint_fi_FI.ts
+++ b/languages/iricGdPoint_fi_FI.ts
@@ -31,6 +31,14 @@
         <source>Finish Defining Point</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeoDataPointColorSimpleSettingDialog</name>

--- a/languages/iricGdPoint_fr_FR.ts
+++ b/languages/iricGdPoint_fr_FR.ts
@@ -31,6 +31,14 @@
         <source>Finish Defining Point</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeoDataPointColorSimpleSettingDialog</name>

--- a/languages/iricGdPoint_gl_ES.ts
+++ b/languages/iricGdPoint_gl_ES.ts
@@ -31,6 +31,14 @@
         <source>Finish Defining Point</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeoDataPointColorSimpleSettingDialog</name>

--- a/languages/iricGdPoint_hi_IN.ts
+++ b/languages/iricGdPoint_hi_IN.ts
@@ -31,6 +31,14 @@
         <source>Finish Defining Point</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeoDataPointColorSimpleSettingDialog</name>

--- a/languages/iricGdPoint_hu_HU.ts
+++ b/languages/iricGdPoint_hu_HU.ts
@@ -31,6 +31,14 @@
         <source>Finish Defining Point</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeoDataPointColorSimpleSettingDialog</name>

--- a/languages/iricGdPoint_id_ID.ts
+++ b/languages/iricGdPoint_id_ID.ts
@@ -31,6 +31,14 @@
         <source>Finish Defining Point</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeoDataPointColorSimpleSettingDialog</name>

--- a/languages/iricGdPoint_is_IS.ts
+++ b/languages/iricGdPoint_is_IS.ts
@@ -31,6 +31,14 @@
         <source>Finish Defining Point</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeoDataPointColorSimpleSettingDialog</name>

--- a/languages/iricGdPoint_it_IT.ts
+++ b/languages/iricGdPoint_it_IT.ts
@@ -31,6 +31,14 @@
         <source>Finish Defining Point</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeoDataPointColorSimpleSettingDialog</name>

--- a/languages/iricGdPoint_ja_JP.ts
+++ b/languages/iricGdPoint_ja_JP.ts
@@ -75,6 +75,14 @@
         <source>Point name and value change</source>
         <translation type="vanished">点の名前と値の変更</translation>
     </message>
+    <message>
+        <source>Point Coordinates</source>
+        <translation>点の座標</translation>
+    </message>
+    <message>
+        <source>Edit Point Coordinates</source>
+        <translation>点の座標の編集</translation>
+    </message>
 </context>
 <context>
     <name>GeoDataPointColorSimpleSettingDialog</name>

--- a/languages/iricGdPoint_ko_KR.ts
+++ b/languages/iricGdPoint_ko_KR.ts
@@ -31,6 +31,14 @@
         <source>Finish Defining Point</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeoDataPointColorSimpleSettingDialog</name>

--- a/languages/iricGdPoint_ky_KG.ts
+++ b/languages/iricGdPoint_ky_KG.ts
@@ -31,6 +31,14 @@
         <source>Finish Defining Point</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeoDataPointColorSimpleSettingDialog</name>

--- a/languages/iricGdPoint_lt_LT.ts
+++ b/languages/iricGdPoint_lt_LT.ts
@@ -31,6 +31,14 @@
         <source>Finish Defining Point</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeoDataPointColorSimpleSettingDialog</name>

--- a/languages/iricGdPoint_lv_LV.ts
+++ b/languages/iricGdPoint_lv_LV.ts
@@ -31,6 +31,14 @@
         <source>Finish Defining Point</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeoDataPointColorSimpleSettingDialog</name>

--- a/languages/iricGdPoint_nb_NO.ts
+++ b/languages/iricGdPoint_nb_NO.ts
@@ -31,6 +31,14 @@
         <source>Finish Defining Point</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeoDataPointColorSimpleSettingDialog</name>

--- a/languages/iricGdPoint_nl_NL.ts
+++ b/languages/iricGdPoint_nl_NL.ts
@@ -31,6 +31,14 @@
         <source>Finish Defining Point</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeoDataPointColorSimpleSettingDialog</name>

--- a/languages/iricGdPoint_pl_PL.ts
+++ b/languages/iricGdPoint_pl_PL.ts
@@ -31,6 +31,14 @@
         <source>Finish Defining Point</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeoDataPointColorSimpleSettingDialog</name>

--- a/languages/iricGdPoint_pt_BR.ts
+++ b/languages/iricGdPoint_pt_BR.ts
@@ -31,6 +31,14 @@
         <source>Finish Defining Point</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeoDataPointColorSimpleSettingDialog</name>

--- a/languages/iricGdPoint_pt_PT.ts
+++ b/languages/iricGdPoint_pt_PT.ts
@@ -31,6 +31,14 @@
         <source>Finish Defining Point</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeoDataPointColorSimpleSettingDialog</name>

--- a/languages/iricGdPoint_ro_RO.ts
+++ b/languages/iricGdPoint_ro_RO.ts
@@ -31,6 +31,14 @@
         <source>Finish Defining Point</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeoDataPointColorSimpleSettingDialog</name>

--- a/languages/iricGdPoint_ru_RU.ts
+++ b/languages/iricGdPoint_ru_RU.ts
@@ -31,6 +31,14 @@
         <source>Finish Defining Point</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeoDataPointColorSimpleSettingDialog</name>

--- a/languages/iricGdPoint_sl_SI.ts
+++ b/languages/iricGdPoint_sl_SI.ts
@@ -31,6 +31,14 @@
         <source>Finish Defining Point</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeoDataPointColorSimpleSettingDialog</name>

--- a/languages/iricGdPoint_sv_SE.ts
+++ b/languages/iricGdPoint_sv_SE.ts
@@ -31,6 +31,14 @@
         <source>Finish Defining Point</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeoDataPointColorSimpleSettingDialog</name>

--- a/languages/iricGdPoint_th_TH.ts
+++ b/languages/iricGdPoint_th_TH.ts
@@ -31,6 +31,14 @@
         <source>Finish Defining Point</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeoDataPointColorSimpleSettingDialog</name>

--- a/languages/iricGdPoint_tr_TR.ts
+++ b/languages/iricGdPoint_tr_TR.ts
@@ -31,6 +31,14 @@
         <source>Finish Defining Point</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeoDataPointColorSimpleSettingDialog</name>

--- a/languages/iricGdPoint_uk_UA.ts
+++ b/languages/iricGdPoint_uk_UA.ts
@@ -31,6 +31,14 @@
         <source>Finish Defining Point</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeoDataPointColorSimpleSettingDialog</name>

--- a/languages/iricGdPoint_vi_VN.ts
+++ b/languages/iricGdPoint_vi_VN.ts
@@ -31,6 +31,14 @@
         <source>Finish Defining Point</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeoDataPointColorSimpleSettingDialog</name>

--- a/languages/iricGdPoint_zh_CN.ts
+++ b/languages/iricGdPoint_zh_CN.ts
@@ -31,6 +31,14 @@
         <source>Finish Defining Point</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeoDataPointColorSimpleSettingDialog</name>

--- a/languages/iricGdPoint_zh_TW.ts
+++ b/languages/iricGdPoint_zh_TW.ts
@@ -31,6 +31,14 @@
         <source>Finish Defining Point</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeoDataPointColorSimpleSettingDialog</name>

--- a/languages/iricGdPolyLineGroup_ar_EG.ts
+++ b/languages/iricGdPolyLineGroup_ar_EG.ts
@@ -40,6 +40,108 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolyLineGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polylines)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polylines) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Line should have two points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;lid&quot; value in line %1. &quot;lid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolyLineGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/languages/iricGdPolyLineGroup_bg_BG.ts
+++ b/languages/iricGdPolyLineGroup_bg_BG.ts
@@ -40,6 +40,108 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolyLineGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polylines)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polylines) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Line should have two points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;lid&quot; value in line %1. &quot;lid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolyLineGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/languages/iricGdPolyLineGroup_bs_BA.ts
+++ b/languages/iricGdPolyLineGroup_bs_BA.ts
@@ -40,6 +40,108 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolyLineGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polylines)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polylines) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Line should have two points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;lid&quot; value in line %1. &quot;lid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolyLineGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/languages/iricGdPolyLineGroup_ca_ES.ts
+++ b/languages/iricGdPolyLineGroup_ca_ES.ts
@@ -40,6 +40,108 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolyLineGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polylines)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polylines) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Line should have two points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;lid&quot; value in line %1. &quot;lid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolyLineGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/languages/iricGdPolyLineGroup_cs_CZ.ts
+++ b/languages/iricGdPolyLineGroup_cs_CZ.ts
@@ -40,6 +40,108 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolyLineGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polylines)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polylines) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Line should have two points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;lid&quot; value in line %1. &quot;lid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolyLineGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/languages/iricGdPolyLineGroup_da_DK.ts
+++ b/languages/iricGdPolyLineGroup_da_DK.ts
@@ -40,6 +40,108 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolyLineGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polylines)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polylines) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Line should have two points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;lid&quot; value in line %1. &quot;lid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolyLineGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/languages/iricGdPolyLineGroup_de_DE.ts
+++ b/languages/iricGdPolyLineGroup_de_DE.ts
@@ -40,6 +40,108 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolyLineGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polylines)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polylines) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Line should have two points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;lid&quot; value in line %1. &quot;lid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolyLineGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/languages/iricGdPolyLineGroup_el_GR.ts
+++ b/languages/iricGdPolyLineGroup_el_GR.ts
@@ -40,6 +40,108 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolyLineGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polylines)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polylines) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Line should have two points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;lid&quot; value in line %1. &quot;lid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolyLineGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/languages/iricGdPolyLineGroup_es_ES.ts
+++ b/languages/iricGdPolyLineGroup_es_ES.ts
@@ -40,6 +40,108 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolyLineGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polylines)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polylines) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Line should have two points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;lid&quot; value in line %1. &quot;lid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolyLineGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/languages/iricGdPolyLineGroup_et_EE.ts
+++ b/languages/iricGdPolyLineGroup_et_EE.ts
@@ -40,6 +40,108 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolyLineGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polylines)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polylines) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Line should have two points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;lid&quot; value in line %1. &quot;lid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolyLineGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/languages/iricGdPolyLineGroup_eu_ES.ts
+++ b/languages/iricGdPolyLineGroup_eu_ES.ts
@@ -40,6 +40,108 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolyLineGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polylines)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polylines) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Line should have two points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;lid&quot; value in line %1. &quot;lid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolyLineGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/languages/iricGdPolyLineGroup_fi_FI.ts
+++ b/languages/iricGdPolyLineGroup_fi_FI.ts
@@ -40,6 +40,108 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolyLineGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polylines)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polylines) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Line should have two points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;lid&quot; value in line %1. &quot;lid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolyLineGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/languages/iricGdPolyLineGroup_fr_FR.ts
+++ b/languages/iricGdPolyLineGroup_fr_FR.ts
@@ -40,6 +40,108 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolyLineGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polylines)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polylines) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Line should have two points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;lid&quot; value in line %1. &quot;lid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolyLineGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/languages/iricGdPolyLineGroup_gl_ES.ts
+++ b/languages/iricGdPolyLineGroup_gl_ES.ts
@@ -40,6 +40,108 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolyLineGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polylines)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polylines) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Line should have two points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;lid&quot; value in line %1. &quot;lid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolyLineGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/languages/iricGdPolyLineGroup_hi_IN.ts
+++ b/languages/iricGdPolyLineGroup_hi_IN.ts
@@ -40,6 +40,108 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolyLineGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polylines)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polylines) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Line should have two points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;lid&quot; value in line %1. &quot;lid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolyLineGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/languages/iricGdPolyLineGroup_hu_HU.ts
+++ b/languages/iricGdPolyLineGroup_hu_HU.ts
@@ -40,6 +40,108 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolyLineGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polylines)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polylines) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Line should have two points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;lid&quot; value in line %1. &quot;lid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolyLineGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/languages/iricGdPolyLineGroup_id_ID.ts
+++ b/languages/iricGdPolyLineGroup_id_ID.ts
@@ -40,6 +40,108 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolyLineGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polylines)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polylines) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Line should have two points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;lid&quot; value in line %1. &quot;lid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolyLineGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/languages/iricGdPolyLineGroup_is_IS.ts
+++ b/languages/iricGdPolyLineGroup_is_IS.ts
@@ -40,6 +40,108 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolyLineGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polylines)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polylines) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Line should have two points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;lid&quot; value in line %1. &quot;lid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolyLineGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/languages/iricGdPolyLineGroup_it_IT.ts
+++ b/languages/iricGdPolyLineGroup_it_IT.ts
@@ -40,6 +40,108 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolyLineGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polylines)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polylines) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Line should have two points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;lid&quot; value in line %1. &quot;lid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolyLineGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/languages/iricGdPolyLineGroup_ja_JP.ts
+++ b/languages/iricGdPolyLineGroup_ja_JP.ts
@@ -217,6 +217,108 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolyLineGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation>CSV ファイル</translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation>エラー</translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation>%1 へのエクスポートでエラーが発生しました。</translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation>CSV ファイル (*.csv)</translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polylines)</source>
+        <translation>CSV ファイル (線)</translation>
+    </message>
+    <message>
+        <source>CSV file (Polylines) (*.csv)</source>
+        <translation>CSV ファイル (線) (*.csv)</translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation>エラー</translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation>%1 を開けませんでした。</translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation>ヘッダ行の読み込み中にエラーが発生しました。UTF-8 エンコーディングで保存されているか確認してください。</translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation>ヘッダ行の読み込み中にエラーが発生しました。ヘッダには5列以上データがなくてはいけません。</translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation>ヘッダ行の読み込み中にエラーが発生しました。ヘッダには6列以上データがなくてはいけません。</translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation>ヘッダ行の読み込み中にエラーが発生しました。%1 列目の値は &quot;%2&quot; のはずですが、&quot;%3&quot; が指定されています。</translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation>%1行目の読み込み中にエラーが発生しました。データがありません。</translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Line should have two points at least.</source>
+        <translation>%1行目の読み込み中にエラーが発生しました。線には最低限点が2つなくてはいけません。</translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation>%1行目の読み込み中にエラーが発生しました。UTF-8 エンコーディングで保存されているか確認してください。</translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation>%1行目の読み込み中にエラーが発生しました。5列以上データがなくてはいけません。</translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation>%1行目の読み込み中にエラーが発生しました。6列以上データがなくてはいけません。</translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;lid&quot; value in line %1. &quot;lid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation>%1行目の &quot;lid&quot; の読み込み中にエラーが発生しました。 &quot;lid&quot; は整数値でなくてはいけませんが、 &quot;%2&quot; が指定されました。</translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation>%1行目の &quot;vid&quot; の読み込み中にエラーが発生しました。 &quot;vid&quot; は整数値でなくてはいけませんが、 &quot;%2&quot; が指定されました。</translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation>%1行目の &quot;x&quot; の読み込み中にエラーが発生しました。 &quot;x&quot; は実数値でなくてはいけませんが、 &quot;%2&quot; が指定されました。</translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation>%1行目の &quot;y&quot; の読み込み中にエラーが発生しました。 &quot;y&quot; は実数値でなくてはいけませんが、 &quot;%2&quot; が指定されました。</translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation>%1行目の &quot;value&quot; の読み込み中にエラーが発生しました。 &quot;value&quot; は実数値でなくてはいけませんが、 &quot;%2&quot; が指定されました。</translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation>%1行目の読み込み中にエラーが発生しました。 &quot;name&quot; は同じ &quot;lid&quot; の行で共通である必要があります。</translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation>%1行目の読み込み中にエラーが発生しました。 &quot;value&quot; は同じ &quot;lid&quot; の行で共通である必要があります。</translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolyLineGroupMergeSettingDialog</name>
     <message>
         <source>Select data to merge</source>

--- a/languages/iricGdPolyLineGroup_ko_KR.ts
+++ b/languages/iricGdPolyLineGroup_ko_KR.ts
@@ -40,6 +40,108 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolyLineGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polylines)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polylines) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Line should have two points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;lid&quot; value in line %1. &quot;lid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolyLineGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/languages/iricGdPolyLineGroup_ky_KG.ts
+++ b/languages/iricGdPolyLineGroup_ky_KG.ts
@@ -40,6 +40,108 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolyLineGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polylines)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polylines) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Line should have two points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;lid&quot; value in line %1. &quot;lid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolyLineGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/languages/iricGdPolyLineGroup_lt_LT.ts
+++ b/languages/iricGdPolyLineGroup_lt_LT.ts
@@ -40,6 +40,108 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolyLineGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polylines)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polylines) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Line should have two points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;lid&quot; value in line %1. &quot;lid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolyLineGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/languages/iricGdPolyLineGroup_lv_LV.ts
+++ b/languages/iricGdPolyLineGroup_lv_LV.ts
@@ -40,6 +40,108 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolyLineGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polylines)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polylines) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Line should have two points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;lid&quot; value in line %1. &quot;lid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolyLineGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/languages/iricGdPolyLineGroup_nb_NO.ts
+++ b/languages/iricGdPolyLineGroup_nb_NO.ts
@@ -40,6 +40,108 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolyLineGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polylines)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polylines) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Line should have two points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;lid&quot; value in line %1. &quot;lid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolyLineGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/languages/iricGdPolyLineGroup_nl_NL.ts
+++ b/languages/iricGdPolyLineGroup_nl_NL.ts
@@ -40,6 +40,108 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolyLineGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polylines)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polylines) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Line should have two points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;lid&quot; value in line %1. &quot;lid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolyLineGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/languages/iricGdPolyLineGroup_pl_PL.ts
+++ b/languages/iricGdPolyLineGroup_pl_PL.ts
@@ -40,6 +40,108 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolyLineGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polylines)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polylines) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Line should have two points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;lid&quot; value in line %1. &quot;lid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolyLineGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/languages/iricGdPolyLineGroup_pt_BR.ts
+++ b/languages/iricGdPolyLineGroup_pt_BR.ts
@@ -40,6 +40,108 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolyLineGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polylines)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polylines) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Line should have two points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;lid&quot; value in line %1. &quot;lid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolyLineGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/languages/iricGdPolyLineGroup_pt_PT.ts
+++ b/languages/iricGdPolyLineGroup_pt_PT.ts
@@ -40,6 +40,108 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolyLineGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polylines)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polylines) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Line should have two points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;lid&quot; value in line %1. &quot;lid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolyLineGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/languages/iricGdPolyLineGroup_ro_RO.ts
+++ b/languages/iricGdPolyLineGroup_ro_RO.ts
@@ -40,6 +40,108 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolyLineGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polylines)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polylines) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Line should have two points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;lid&quot; value in line %1. &quot;lid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolyLineGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/languages/iricGdPolyLineGroup_ru_RU.ts
+++ b/languages/iricGdPolyLineGroup_ru_RU.ts
@@ -40,6 +40,108 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolyLineGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polylines)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polylines) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Line should have two points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;lid&quot; value in line %1. &quot;lid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolyLineGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/languages/iricGdPolyLineGroup_sl_SI.ts
+++ b/languages/iricGdPolyLineGroup_sl_SI.ts
@@ -40,6 +40,108 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolyLineGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polylines)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polylines) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Line should have two points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;lid&quot; value in line %1. &quot;lid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolyLineGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/languages/iricGdPolyLineGroup_sv_SE.ts
+++ b/languages/iricGdPolyLineGroup_sv_SE.ts
@@ -40,6 +40,108 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolyLineGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polylines)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polylines) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Line should have two points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;lid&quot; value in line %1. &quot;lid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolyLineGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/languages/iricGdPolyLineGroup_th_TH.ts
+++ b/languages/iricGdPolyLineGroup_th_TH.ts
@@ -40,6 +40,108 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolyLineGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polylines)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polylines) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Line should have two points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;lid&quot; value in line %1. &quot;lid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolyLineGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/languages/iricGdPolyLineGroup_tr_TR.ts
+++ b/languages/iricGdPolyLineGroup_tr_TR.ts
@@ -40,6 +40,108 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolyLineGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polylines)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polylines) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Line should have two points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;lid&quot; value in line %1. &quot;lid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolyLineGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/languages/iricGdPolyLineGroup_uk_UA.ts
+++ b/languages/iricGdPolyLineGroup_uk_UA.ts
@@ -40,6 +40,108 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolyLineGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polylines)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polylines) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Line should have two points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;lid&quot; value in line %1. &quot;lid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolyLineGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/languages/iricGdPolyLineGroup_vi_VN.ts
+++ b/languages/iricGdPolyLineGroup_vi_VN.ts
@@ -40,6 +40,108 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolyLineGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polylines)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polylines) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Line should have two points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;lid&quot; value in line %1. &quot;lid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolyLineGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/languages/iricGdPolyLineGroup_zh_CN.ts
+++ b/languages/iricGdPolyLineGroup_zh_CN.ts
@@ -40,6 +40,108 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolyLineGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polylines)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polylines) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Line should have two points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;lid&quot; value in line %1. &quot;lid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolyLineGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/languages/iricGdPolyLineGroup_zh_TW.ts
+++ b/languages/iricGdPolyLineGroup_zh_TW.ts
@@ -40,6 +40,108 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolyLineGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polylines)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polylines) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Line should have two points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;lid&quot; value in line %1. &quot;lid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolyLineGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/languages/iricGdPolygonGroup_ar_EG.ts
+++ b/languages/iricGdPolygonGroup_ar_EG.ts
@@ -36,6 +36,116 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolygonGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Some polygon in this polygon group has holes, but holes are not exported to CSV file. If you want to export holes, please export to ESRI Shapefile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolygonGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polygons)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polygons) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Polygon should have three points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;pid&quot; value in line %1. &quot;pid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolygonGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/languages/iricGdPolygonGroup_bg_BG.ts
+++ b/languages/iricGdPolygonGroup_bg_BG.ts
@@ -36,6 +36,116 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolygonGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Some polygon in this polygon group has holes, but holes are not exported to CSV file. If you want to export holes, please export to ESRI Shapefile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolygonGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polygons)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polygons) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Polygon should have three points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;pid&quot; value in line %1. &quot;pid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolygonGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/languages/iricGdPolygonGroup_bs_BA.ts
+++ b/languages/iricGdPolygonGroup_bs_BA.ts
@@ -36,6 +36,116 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolygonGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Some polygon in this polygon group has holes, but holes are not exported to CSV file. If you want to export holes, please export to ESRI Shapefile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolygonGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polygons)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polygons) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Polygon should have three points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;pid&quot; value in line %1. &quot;pid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolygonGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/languages/iricGdPolygonGroup_ca_ES.ts
+++ b/languages/iricGdPolygonGroup_ca_ES.ts
@@ -36,6 +36,116 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolygonGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Some polygon in this polygon group has holes, but holes are not exported to CSV file. If you want to export holes, please export to ESRI Shapefile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolygonGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polygons)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polygons) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Polygon should have three points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;pid&quot; value in line %1. &quot;pid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolygonGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/languages/iricGdPolygonGroup_cs_CZ.ts
+++ b/languages/iricGdPolygonGroup_cs_CZ.ts
@@ -36,6 +36,116 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolygonGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Some polygon in this polygon group has holes, but holes are not exported to CSV file. If you want to export holes, please export to ESRI Shapefile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolygonGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polygons)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polygons) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Polygon should have three points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;pid&quot; value in line %1. &quot;pid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolygonGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/languages/iricGdPolygonGroup_da_DK.ts
+++ b/languages/iricGdPolygonGroup_da_DK.ts
@@ -36,6 +36,116 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolygonGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Some polygon in this polygon group has holes, but holes are not exported to CSV file. If you want to export holes, please export to ESRI Shapefile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolygonGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polygons)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polygons) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Polygon should have three points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;pid&quot; value in line %1. &quot;pid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolygonGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/languages/iricGdPolygonGroup_de_DE.ts
+++ b/languages/iricGdPolygonGroup_de_DE.ts
@@ -36,6 +36,116 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolygonGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Some polygon in this polygon group has holes, but holes are not exported to CSV file. If you want to export holes, please export to ESRI Shapefile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolygonGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polygons)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polygons) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Polygon should have three points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;pid&quot; value in line %1. &quot;pid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolygonGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/languages/iricGdPolygonGroup_el_GR.ts
+++ b/languages/iricGdPolygonGroup_el_GR.ts
@@ -36,6 +36,116 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolygonGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Some polygon in this polygon group has holes, but holes are not exported to CSV file. If you want to export holes, please export to ESRI Shapefile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolygonGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polygons)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polygons) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Polygon should have three points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;pid&quot; value in line %1. &quot;pid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolygonGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/languages/iricGdPolygonGroup_es_ES.ts
+++ b/languages/iricGdPolygonGroup_es_ES.ts
@@ -106,6 +106,116 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolygonGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation type="unfinished">Aviso</translation>
+    </message>
+    <message>
+        <source>Some polygon in this polygon group has holes, but holes are not exported to CSV file. If you want to export holes, please export to ESRI Shapefile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolygonGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polygons)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polygons) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Polygon should have three points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;pid&quot; value in line %1. &quot;pid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolygonGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/languages/iricGdPolygonGroup_et_EE.ts
+++ b/languages/iricGdPolygonGroup_et_EE.ts
@@ -36,6 +36,116 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolygonGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Some polygon in this polygon group has holes, but holes are not exported to CSV file. If you want to export holes, please export to ESRI Shapefile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolygonGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polygons)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polygons) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Polygon should have three points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;pid&quot; value in line %1. &quot;pid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolygonGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/languages/iricGdPolygonGroup_eu_ES.ts
+++ b/languages/iricGdPolygonGroup_eu_ES.ts
@@ -36,6 +36,116 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolygonGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Some polygon in this polygon group has holes, but holes are not exported to CSV file. If you want to export holes, please export to ESRI Shapefile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolygonGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polygons)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polygons) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Polygon should have three points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;pid&quot; value in line %1. &quot;pid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolygonGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/languages/iricGdPolygonGroup_fi_FI.ts
+++ b/languages/iricGdPolygonGroup_fi_FI.ts
@@ -36,6 +36,116 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolygonGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Some polygon in this polygon group has holes, but holes are not exported to CSV file. If you want to export holes, please export to ESRI Shapefile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolygonGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polygons)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polygons) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Polygon should have three points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;pid&quot; value in line %1. &quot;pid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolygonGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/languages/iricGdPolygonGroup_fr_FR.ts
+++ b/languages/iricGdPolygonGroup_fr_FR.ts
@@ -36,6 +36,116 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolygonGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Some polygon in this polygon group has holes, but holes are not exported to CSV file. If you want to export holes, please export to ESRI Shapefile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolygonGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polygons)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polygons) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Polygon should have three points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;pid&quot; value in line %1. &quot;pid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolygonGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/languages/iricGdPolygonGroup_gl_ES.ts
+++ b/languages/iricGdPolygonGroup_gl_ES.ts
@@ -36,6 +36,116 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolygonGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Some polygon in this polygon group has holes, but holes are not exported to CSV file. If you want to export holes, please export to ESRI Shapefile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolygonGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polygons)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polygons) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Polygon should have three points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;pid&quot; value in line %1. &quot;pid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolygonGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/languages/iricGdPolygonGroup_hi_IN.ts
+++ b/languages/iricGdPolygonGroup_hi_IN.ts
@@ -36,6 +36,116 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolygonGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Some polygon in this polygon group has holes, but holes are not exported to CSV file. If you want to export holes, please export to ESRI Shapefile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolygonGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polygons)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polygons) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Polygon should have three points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;pid&quot; value in line %1. &quot;pid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolygonGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/languages/iricGdPolygonGroup_hu_HU.ts
+++ b/languages/iricGdPolygonGroup_hu_HU.ts
@@ -36,6 +36,116 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolygonGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Some polygon in this polygon group has holes, but holes are not exported to CSV file. If you want to export holes, please export to ESRI Shapefile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolygonGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polygons)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polygons) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Polygon should have three points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;pid&quot; value in line %1. &quot;pid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolygonGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/languages/iricGdPolygonGroup_id_ID.ts
+++ b/languages/iricGdPolygonGroup_id_ID.ts
@@ -36,6 +36,116 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolygonGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Some polygon in this polygon group has holes, but holes are not exported to CSV file. If you want to export holes, please export to ESRI Shapefile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolygonGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polygons)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polygons) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Polygon should have three points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;pid&quot; value in line %1. &quot;pid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolygonGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/languages/iricGdPolygonGroup_is_IS.ts
+++ b/languages/iricGdPolygonGroup_is_IS.ts
@@ -36,6 +36,116 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolygonGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Some polygon in this polygon group has holes, but holes are not exported to CSV file. If you want to export holes, please export to ESRI Shapefile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolygonGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polygons)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polygons) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Polygon should have three points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;pid&quot; value in line %1. &quot;pid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolygonGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/languages/iricGdPolygonGroup_it_IT.ts
+++ b/languages/iricGdPolygonGroup_it_IT.ts
@@ -36,6 +36,116 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolygonGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Some polygon in this polygon group has holes, but holes are not exported to CSV file. If you want to export holes, please export to ESRI Shapefile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolygonGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polygons)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polygons) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Polygon should have three points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;pid&quot; value in line %1. &quot;pid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolygonGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/languages/iricGdPolygonGroup_ja_JP.ts
+++ b/languages/iricGdPolygonGroup_ja_JP.ts
@@ -205,6 +205,116 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolygonGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation>CSV ファイル</translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation>エラー</translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation>%1 へのエクスポートでエラーが発生しました。</translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation>警告</translation>
+    </message>
+    <message>
+        <source>Some polygon in this polygon group has holes, but holes are not exported to CSV file. If you want to export holes, please export to ESRI Shapefile.</source>
+        <translation>ポリゴンに、穴が空いているものがありますが、 CSVファイルには穴の情報をエクスポートできません。穴の情報をエクスポートしたい場合、ESRIシェープファイルにエクスポートしてください。</translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation>CSV ファイル (*.csv)</translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolygonGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polygons)</source>
+        <translation>CSV ファイル (ポリゴン)</translation>
+    </message>
+    <message>
+        <source>CSV file (Polygons) (*.csv)</source>
+        <translation>CSV ファイル (ポリゴン) (*.csv)</translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation>エラー</translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation>%1 を開けませんでした。</translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation>ヘッダ行の読み込み中にエラーが発生しました。UTF-8 エンコーディングで保存されているか確認してください。</translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation>ヘッダ行の読み込み中にエラーが発生しました。ヘッダには5列以上データがなくてはいけません。</translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation>ヘッダ行の読み込み中にエラーが発生しました。ヘッダには5列以上データがなくてはいけません。</translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation>ヘッダ行の読み込み中にエラーが発生しました。ヘッダには6列以上データがなくてはいけません。</translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation>%1行目の読み込み中にエラーが発生しました。データがありません。</translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Polygon should have three points at least.</source>
+        <translation>ヘッダ行の読み込み中にエラーが発生しました。%1 列目の値は &quot;%2&quot; のはずですが、&quot;%3&quot; が指定されています。</translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation>%1行目の読み込み中にエラーが発生しました。UTF-8 エンコーディングで保存されているか確認してください。</translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation>%1行目の読み込み中にエラーが発生しました。5列以上データがなくてはいけません。</translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation>%1行目の読み込み中にエラーが発生しました。6列以上データがなくてはいけません。</translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;pid&quot; value in line %1. &quot;pid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation>%1行目の &quot;pid&quot; の読み込み中にエラーが発生しました。 &quot;pid&quot; は整数値でなくてはいけませんが、 &quot;%2&quot; が指定されました。</translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation>%1行目の &quot;vid&quot; の読み込み中にエラーが発生しました。 &quot;vid&quot; は整数値でなくてはいけませんが、 &quot;%2&quot; が指定されました。</translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation>%1行目の &quot;x&quot; の読み込み中にエラーが発生しました。 &quot;x&quot; は実数値でなくてはいけませんが、 &quot;%2&quot; が指定されました。</translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation>%1行目の &quot;y&quot; の読み込み中にエラーが発生しました。 &quot;y&quot; は実数値でなくてはいけませんが、 &quot;%2&quot; が指定されました。</translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation>%1行目の &quot;value&quot; の読み込み中にエラーが発生しました。 &quot;value&quot; は実数値でなくてはいけませんが、 &quot;%2&quot; が指定されました。</translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation>%1行目の読み込み中にエラーが発生しました。 &quot;name&quot; は同じ &quot;pid&quot; の行で共通である必要があります。</translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation>%1行目の読み込み中にエラーが発生しました。 &quot;value&quot; は同じ &quot;pid&quot; の行で共通である必要があります。</translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolygonGroupMergeSettingDialog</name>
     <message>
         <source>Select data to merge</source>

--- a/languages/iricGdPolygonGroup_ko_KR.ts
+++ b/languages/iricGdPolygonGroup_ko_KR.ts
@@ -36,6 +36,116 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolygonGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Some polygon in this polygon group has holes, but holes are not exported to CSV file. If you want to export holes, please export to ESRI Shapefile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolygonGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polygons)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polygons) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Polygon should have three points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;pid&quot; value in line %1. &quot;pid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolygonGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/languages/iricGdPolygonGroup_ky_KG.ts
+++ b/languages/iricGdPolygonGroup_ky_KG.ts
@@ -36,6 +36,116 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolygonGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Some polygon in this polygon group has holes, but holes are not exported to CSV file. If you want to export holes, please export to ESRI Shapefile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolygonGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polygons)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polygons) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Polygon should have three points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;pid&quot; value in line %1. &quot;pid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolygonGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/languages/iricGdPolygonGroup_lt_LT.ts
+++ b/languages/iricGdPolygonGroup_lt_LT.ts
@@ -36,6 +36,116 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolygonGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Some polygon in this polygon group has holes, but holes are not exported to CSV file. If you want to export holes, please export to ESRI Shapefile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolygonGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polygons)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polygons) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Polygon should have three points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;pid&quot; value in line %1. &quot;pid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolygonGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/languages/iricGdPolygonGroup_lv_LV.ts
+++ b/languages/iricGdPolygonGroup_lv_LV.ts
@@ -36,6 +36,116 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolygonGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Some polygon in this polygon group has holes, but holes are not exported to CSV file. If you want to export holes, please export to ESRI Shapefile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolygonGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polygons)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polygons) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Polygon should have three points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;pid&quot; value in line %1. &quot;pid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolygonGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/languages/iricGdPolygonGroup_nb_NO.ts
+++ b/languages/iricGdPolygonGroup_nb_NO.ts
@@ -36,6 +36,116 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolygonGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Some polygon in this polygon group has holes, but holes are not exported to CSV file. If you want to export holes, please export to ESRI Shapefile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolygonGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polygons)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polygons) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Polygon should have three points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;pid&quot; value in line %1. &quot;pid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolygonGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/languages/iricGdPolygonGroup_nl_NL.ts
+++ b/languages/iricGdPolygonGroup_nl_NL.ts
@@ -36,6 +36,116 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolygonGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Some polygon in this polygon group has holes, but holes are not exported to CSV file. If you want to export holes, please export to ESRI Shapefile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolygonGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polygons)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polygons) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Polygon should have three points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;pid&quot; value in line %1. &quot;pid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolygonGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/languages/iricGdPolygonGroup_pl_PL.ts
+++ b/languages/iricGdPolygonGroup_pl_PL.ts
@@ -36,6 +36,116 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolygonGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Some polygon in this polygon group has holes, but holes are not exported to CSV file. If you want to export holes, please export to ESRI Shapefile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolygonGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polygons)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polygons) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Polygon should have three points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;pid&quot; value in line %1. &quot;pid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolygonGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/languages/iricGdPolygonGroup_pt_BR.ts
+++ b/languages/iricGdPolygonGroup_pt_BR.ts
@@ -99,6 +99,116 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolygonGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished">Erro</translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation type="unfinished">Atencao</translation>
+    </message>
+    <message>
+        <source>Some polygon in this polygon group has holes, but holes are not exported to CSV file. If you want to export holes, please export to ESRI Shapefile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolygonGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polygons)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polygons) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished">Erro</translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Polygon should have three points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;pid&quot; value in line %1. &quot;pid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolygonGroupMergeSettingDialog</name>
     <message>
         <source>Select data to merge</source>

--- a/languages/iricGdPolygonGroup_pt_PT.ts
+++ b/languages/iricGdPolygonGroup_pt_PT.ts
@@ -36,6 +36,116 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolygonGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Some polygon in this polygon group has holes, but holes are not exported to CSV file. If you want to export holes, please export to ESRI Shapefile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolygonGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polygons)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polygons) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Polygon should have three points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;pid&quot; value in line %1. &quot;pid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolygonGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/languages/iricGdPolygonGroup_ro_RO.ts
+++ b/languages/iricGdPolygonGroup_ro_RO.ts
@@ -36,6 +36,116 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolygonGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Some polygon in this polygon group has holes, but holes are not exported to CSV file. If you want to export holes, please export to ESRI Shapefile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolygonGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polygons)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polygons) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Polygon should have three points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;pid&quot; value in line %1. &quot;pid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolygonGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/languages/iricGdPolygonGroup_ru_RU.ts
+++ b/languages/iricGdPolygonGroup_ru_RU.ts
@@ -36,6 +36,116 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolygonGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Some polygon in this polygon group has holes, but holes are not exported to CSV file. If you want to export holes, please export to ESRI Shapefile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolygonGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polygons)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polygons) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Polygon should have three points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;pid&quot; value in line %1. &quot;pid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolygonGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/languages/iricGdPolygonGroup_sl_SI.ts
+++ b/languages/iricGdPolygonGroup_sl_SI.ts
@@ -36,6 +36,116 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolygonGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Some polygon in this polygon group has holes, but holes are not exported to CSV file. If you want to export holes, please export to ESRI Shapefile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolygonGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polygons)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polygons) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Polygon should have three points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;pid&quot; value in line %1. &quot;pid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolygonGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/languages/iricGdPolygonGroup_sv_SE.ts
+++ b/languages/iricGdPolygonGroup_sv_SE.ts
@@ -36,6 +36,116 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolygonGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Some polygon in this polygon group has holes, but holes are not exported to CSV file. If you want to export holes, please export to ESRI Shapefile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolygonGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polygons)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polygons) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Polygon should have three points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;pid&quot; value in line %1. &quot;pid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolygonGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/languages/iricGdPolygonGroup_th_TH.ts
+++ b/languages/iricGdPolygonGroup_th_TH.ts
@@ -36,6 +36,116 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolygonGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Some polygon in this polygon group has holes, but holes are not exported to CSV file. If you want to export holes, please export to ESRI Shapefile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolygonGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polygons)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polygons) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Polygon should have three points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;pid&quot; value in line %1. &quot;pid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolygonGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/languages/iricGdPolygonGroup_tr_TR.ts
+++ b/languages/iricGdPolygonGroup_tr_TR.ts
@@ -36,6 +36,116 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolygonGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Some polygon in this polygon group has holes, but holes are not exported to CSV file. If you want to export holes, please export to ESRI Shapefile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolygonGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polygons)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polygons) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Polygon should have three points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;pid&quot; value in line %1. &quot;pid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolygonGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/languages/iricGdPolygonGroup_uk_UA.ts
+++ b/languages/iricGdPolygonGroup_uk_UA.ts
@@ -36,6 +36,116 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolygonGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Some polygon in this polygon group has holes, but holes are not exported to CSV file. If you want to export holes, please export to ESRI Shapefile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolygonGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polygons)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polygons) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Polygon should have three points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;pid&quot; value in line %1. &quot;pid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolygonGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/languages/iricGdPolygonGroup_vi_VN.ts
+++ b/languages/iricGdPolygonGroup_vi_VN.ts
@@ -36,6 +36,116 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolygonGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Some polygon in this polygon group has holes, but holes are not exported to CSV file. If you want to export holes, please export to ESRI Shapefile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolygonGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polygons)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polygons) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Polygon should have three points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;pid&quot; value in line %1. &quot;pid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolygonGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/languages/iricGdPolygonGroup_zh_CN.ts
+++ b/languages/iricGdPolygonGroup_zh_CN.ts
@@ -114,6 +114,116 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolygonGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished">错误</translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation type="unfinished">警告</translation>
+    </message>
+    <message>
+        <source>Some polygon in this polygon group has holes, but holes are not exported to CSV file. If you want to export holes, please export to ESRI Shapefile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolygonGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polygons)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polygons) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished">错误</translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Polygon should have three points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;pid&quot; value in line %1. &quot;pid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolygonGroupMergeSettingDialog</name>
     <message>
         <source>Select data to merge</source>

--- a/languages/iricGdPolygonGroup_zh_TW.ts
+++ b/languages/iricGdPolygonGroup_zh_TW.ts
@@ -36,6 +36,116 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolygonGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Some polygon in this polygon group has holes, but holes are not exported to CSV file. If you want to export holes, please export to ESRI Shapefile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolygonGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polygons)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polygons) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Polygon should have three points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;pid&quot; value in line %1. &quot;pid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolygonGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/libs/geodata/point/geodatapoint.cpp
+++ b/libs/geodata/point/geodatapoint.cpp
@@ -1,5 +1,6 @@
 #include "geodatapoint.h"
 
+#include "private/geodatapoint_coordinateseditor.h"
 #include "private/geodatapoint_finishpointdefinitioncommand.h"
 #include "private/geodatapoint_impl.h"
 
@@ -95,17 +96,11 @@ bool GeoDataPoint::addToolBarButtons(QToolBar* /*parent*/)
 
 void GeoDataPoint::informSelection(PreProcessorGraphicsViewInterface* v)
 {
-	// @todo
-	// impl->m_polyLine->setActive(true);
-
 	updateMouseCursor(v);
 }
 
 void GeoDataPoint::informDeselection(PreProcessorGraphicsViewInterface* v)
 {
-	// @todo
-	// impl->m_polyLine->setActive(false);
-
 	v->unsetCursor();
 }
 
@@ -244,7 +239,7 @@ void GeoDataPoint::restoreMouseEventMode()
 
 void GeoDataPoint::editCoordinates()
 {
-	// @todo implement this!
+	CoordinatesEditor::edit(this);
 }
 
 void GeoDataPoint::doApplyOffset(double x, double y)

--- a/libs/geodata/point/geodatapoint.cpp
+++ b/libs/geodata/point/geodatapoint.cpp
@@ -250,8 +250,8 @@ void GeoDataPoint::editCoordinates()
 void GeoDataPoint::doApplyOffset(double x, double y)
 {
 	auto p = point();
-	p.setX(p.x() + x);
-	p.setY(p.y() + y);
+	p.setX(p.x() - x);
+	p.setY(p.y() - y);
 	setPoint(p);
 }
 

--- a/libs/geodata/point/geodatapoint.h
+++ b/libs/geodata/point/geodatapoint.h
@@ -73,7 +73,10 @@ private:
 
 	QAction* coordEditAction() const;
 
+	class EditCoordinatesCommand;
 	class FinishPointDefiningCommand;
+
+	class CoordinatesEditor;
 
 	class Impl;
 	Impl* impl;

--- a/libs/geodata/point/languages/iricGdPoint_ar_EG.ts
+++ b/libs/geodata/point/languages/iricGdPoint_ar_EG.ts
@@ -31,6 +31,14 @@
         <source>Finish Defining Point</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeoDataPointColorSimpleSettingDialog</name>

--- a/libs/geodata/point/languages/iricGdPoint_bg_BG.ts
+++ b/libs/geodata/point/languages/iricGdPoint_bg_BG.ts
@@ -31,6 +31,14 @@
         <source>Finish Defining Point</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeoDataPointColorSimpleSettingDialog</name>

--- a/libs/geodata/point/languages/iricGdPoint_bs_BA.ts
+++ b/libs/geodata/point/languages/iricGdPoint_bs_BA.ts
@@ -31,6 +31,14 @@
         <source>Finish Defining Point</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeoDataPointColorSimpleSettingDialog</name>

--- a/libs/geodata/point/languages/iricGdPoint_ca_ES.ts
+++ b/libs/geodata/point/languages/iricGdPoint_ca_ES.ts
@@ -31,6 +31,14 @@
         <source>Finish Defining Point</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeoDataPointColorSimpleSettingDialog</name>

--- a/libs/geodata/point/languages/iricGdPoint_cs_CZ.ts
+++ b/libs/geodata/point/languages/iricGdPoint_cs_CZ.ts
@@ -31,6 +31,14 @@
         <source>Finish Defining Point</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeoDataPointColorSimpleSettingDialog</name>

--- a/libs/geodata/point/languages/iricGdPoint_da_DK.ts
+++ b/libs/geodata/point/languages/iricGdPoint_da_DK.ts
@@ -31,6 +31,14 @@
         <source>Finish Defining Point</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeoDataPointColorSimpleSettingDialog</name>

--- a/libs/geodata/point/languages/iricGdPoint_de_DE.ts
+++ b/libs/geodata/point/languages/iricGdPoint_de_DE.ts
@@ -31,6 +31,14 @@
         <source>Finish Defining Point</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeoDataPointColorSimpleSettingDialog</name>

--- a/libs/geodata/point/languages/iricGdPoint_el_GR.ts
+++ b/libs/geodata/point/languages/iricGdPoint_el_GR.ts
@@ -31,6 +31,14 @@
         <source>Finish Defining Point</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeoDataPointColorSimpleSettingDialog</name>

--- a/libs/geodata/point/languages/iricGdPoint_es_ES.ts
+++ b/libs/geodata/point/languages/iricGdPoint_es_ES.ts
@@ -31,6 +31,14 @@
         <source>Finish Defining Point</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeoDataPointColorSimpleSettingDialog</name>

--- a/libs/geodata/point/languages/iricGdPoint_et_EE.ts
+++ b/libs/geodata/point/languages/iricGdPoint_et_EE.ts
@@ -31,6 +31,14 @@
         <source>Finish Defining Point</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeoDataPointColorSimpleSettingDialog</name>

--- a/libs/geodata/point/languages/iricGdPoint_eu_ES.ts
+++ b/libs/geodata/point/languages/iricGdPoint_eu_ES.ts
@@ -31,6 +31,14 @@
         <source>Finish Defining Point</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeoDataPointColorSimpleSettingDialog</name>

--- a/libs/geodata/point/languages/iricGdPoint_fi_FI.ts
+++ b/libs/geodata/point/languages/iricGdPoint_fi_FI.ts
@@ -31,6 +31,14 @@
         <source>Finish Defining Point</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeoDataPointColorSimpleSettingDialog</name>

--- a/libs/geodata/point/languages/iricGdPoint_fr_FR.ts
+++ b/libs/geodata/point/languages/iricGdPoint_fr_FR.ts
@@ -31,6 +31,14 @@
         <source>Finish Defining Point</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeoDataPointColorSimpleSettingDialog</name>

--- a/libs/geodata/point/languages/iricGdPoint_gl_ES.ts
+++ b/libs/geodata/point/languages/iricGdPoint_gl_ES.ts
@@ -31,6 +31,14 @@
         <source>Finish Defining Point</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeoDataPointColorSimpleSettingDialog</name>

--- a/libs/geodata/point/languages/iricGdPoint_hi_IN.ts
+++ b/libs/geodata/point/languages/iricGdPoint_hi_IN.ts
@@ -31,6 +31,14 @@
         <source>Finish Defining Point</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeoDataPointColorSimpleSettingDialog</name>

--- a/libs/geodata/point/languages/iricGdPoint_hu_HU.ts
+++ b/libs/geodata/point/languages/iricGdPoint_hu_HU.ts
@@ -31,6 +31,14 @@
         <source>Finish Defining Point</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeoDataPointColorSimpleSettingDialog</name>

--- a/libs/geodata/point/languages/iricGdPoint_id_ID.ts
+++ b/libs/geodata/point/languages/iricGdPoint_id_ID.ts
@@ -31,6 +31,14 @@
         <source>Finish Defining Point</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeoDataPointColorSimpleSettingDialog</name>

--- a/libs/geodata/point/languages/iricGdPoint_is_IS.ts
+++ b/libs/geodata/point/languages/iricGdPoint_is_IS.ts
@@ -31,6 +31,14 @@
         <source>Finish Defining Point</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeoDataPointColorSimpleSettingDialog</name>

--- a/libs/geodata/point/languages/iricGdPoint_it_IT.ts
+++ b/libs/geodata/point/languages/iricGdPoint_it_IT.ts
@@ -31,6 +31,14 @@
         <source>Finish Defining Point</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeoDataPointColorSimpleSettingDialog</name>

--- a/libs/geodata/point/languages/iricGdPoint_ja_JP.ts
+++ b/libs/geodata/point/languages/iricGdPoint_ja_JP.ts
@@ -75,6 +75,14 @@
         <source>Point name and value change</source>
         <translation type="vanished">点の名前と値の変更</translation>
     </message>
+    <message>
+        <source>Point Coordinates</source>
+        <translation>点の座標</translation>
+    </message>
+    <message>
+        <source>Edit Point Coordinates</source>
+        <translation>点の座標の編集</translation>
+    </message>
 </context>
 <context>
     <name>GeoDataPointColorSimpleSettingDialog</name>

--- a/libs/geodata/point/languages/iricGdPoint_ko_KR.ts
+++ b/libs/geodata/point/languages/iricGdPoint_ko_KR.ts
@@ -31,6 +31,14 @@
         <source>Finish Defining Point</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeoDataPointColorSimpleSettingDialog</name>

--- a/libs/geodata/point/languages/iricGdPoint_ky_KG.ts
+++ b/libs/geodata/point/languages/iricGdPoint_ky_KG.ts
@@ -31,6 +31,14 @@
         <source>Finish Defining Point</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeoDataPointColorSimpleSettingDialog</name>

--- a/libs/geodata/point/languages/iricGdPoint_lt_LT.ts
+++ b/libs/geodata/point/languages/iricGdPoint_lt_LT.ts
@@ -31,6 +31,14 @@
         <source>Finish Defining Point</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeoDataPointColorSimpleSettingDialog</name>

--- a/libs/geodata/point/languages/iricGdPoint_lv_LV.ts
+++ b/libs/geodata/point/languages/iricGdPoint_lv_LV.ts
@@ -31,6 +31,14 @@
         <source>Finish Defining Point</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeoDataPointColorSimpleSettingDialog</name>

--- a/libs/geodata/point/languages/iricGdPoint_nb_NO.ts
+++ b/libs/geodata/point/languages/iricGdPoint_nb_NO.ts
@@ -31,6 +31,14 @@
         <source>Finish Defining Point</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeoDataPointColorSimpleSettingDialog</name>

--- a/libs/geodata/point/languages/iricGdPoint_nl_NL.ts
+++ b/libs/geodata/point/languages/iricGdPoint_nl_NL.ts
@@ -31,6 +31,14 @@
         <source>Finish Defining Point</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeoDataPointColorSimpleSettingDialog</name>

--- a/libs/geodata/point/languages/iricGdPoint_pl_PL.ts
+++ b/libs/geodata/point/languages/iricGdPoint_pl_PL.ts
@@ -31,6 +31,14 @@
         <source>Finish Defining Point</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeoDataPointColorSimpleSettingDialog</name>

--- a/libs/geodata/point/languages/iricGdPoint_pt_BR.ts
+++ b/libs/geodata/point/languages/iricGdPoint_pt_BR.ts
@@ -31,6 +31,14 @@
         <source>Finish Defining Point</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeoDataPointColorSimpleSettingDialog</name>

--- a/libs/geodata/point/languages/iricGdPoint_pt_PT.ts
+++ b/libs/geodata/point/languages/iricGdPoint_pt_PT.ts
@@ -31,6 +31,14 @@
         <source>Finish Defining Point</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeoDataPointColorSimpleSettingDialog</name>

--- a/libs/geodata/point/languages/iricGdPoint_ro_RO.ts
+++ b/libs/geodata/point/languages/iricGdPoint_ro_RO.ts
@@ -31,6 +31,14 @@
         <source>Finish Defining Point</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeoDataPointColorSimpleSettingDialog</name>

--- a/libs/geodata/point/languages/iricGdPoint_ru_RU.ts
+++ b/libs/geodata/point/languages/iricGdPoint_ru_RU.ts
@@ -31,6 +31,14 @@
         <source>Finish Defining Point</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeoDataPointColorSimpleSettingDialog</name>

--- a/libs/geodata/point/languages/iricGdPoint_sl_SI.ts
+++ b/libs/geodata/point/languages/iricGdPoint_sl_SI.ts
@@ -31,6 +31,14 @@
         <source>Finish Defining Point</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeoDataPointColorSimpleSettingDialog</name>

--- a/libs/geodata/point/languages/iricGdPoint_sv_SE.ts
+++ b/libs/geodata/point/languages/iricGdPoint_sv_SE.ts
@@ -31,6 +31,14 @@
         <source>Finish Defining Point</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeoDataPointColorSimpleSettingDialog</name>

--- a/libs/geodata/point/languages/iricGdPoint_th_TH.ts
+++ b/libs/geodata/point/languages/iricGdPoint_th_TH.ts
@@ -31,6 +31,14 @@
         <source>Finish Defining Point</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeoDataPointColorSimpleSettingDialog</name>

--- a/libs/geodata/point/languages/iricGdPoint_tr_TR.ts
+++ b/libs/geodata/point/languages/iricGdPoint_tr_TR.ts
@@ -31,6 +31,14 @@
         <source>Finish Defining Point</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeoDataPointColorSimpleSettingDialog</name>

--- a/libs/geodata/point/languages/iricGdPoint_uk_UA.ts
+++ b/libs/geodata/point/languages/iricGdPoint_uk_UA.ts
@@ -31,6 +31,14 @@
         <source>Finish Defining Point</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeoDataPointColorSimpleSettingDialog</name>

--- a/libs/geodata/point/languages/iricGdPoint_vi_VN.ts
+++ b/libs/geodata/point/languages/iricGdPoint_vi_VN.ts
@@ -31,6 +31,14 @@
         <source>Finish Defining Point</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeoDataPointColorSimpleSettingDialog</name>

--- a/libs/geodata/point/languages/iricGdPoint_zh_CN.ts
+++ b/libs/geodata/point/languages/iricGdPoint_zh_CN.ts
@@ -31,6 +31,14 @@
         <source>Finish Defining Point</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeoDataPointColorSimpleSettingDialog</name>

--- a/libs/geodata/point/languages/iricGdPoint_zh_TW.ts
+++ b/libs/geodata/point/languages/iricGdPoint_zh_TW.ts
@@ -31,6 +31,14 @@
         <source>Finish Defining Point</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Point Coordinates</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GeoDataPointColorSimpleSettingDialog</name>

--- a/libs/geodata/point/point.pro
+++ b/libs/geodata/point/point.pro
@@ -122,6 +122,8 @@ HEADERS += gd_point_global.h \
            geodatapointcreatort.h \
            geodatapointnodemappert.h \
            geodatapointrealcreator.h \
+           private/geodatapoint_coordinateseditor.h \
+           private/geodatapoint_editcoordinatescommand.h \
            private/geodatapoint_finishpointdefinitioncommand.h \
            private/geodatapoint_impl.h \
            private/geodatapointcellmappert_detail.h \
@@ -131,8 +133,9 @@ FORMS += geodatapointcolorsimplesettingdialog.ui
 SOURCES += geodatapoint.cpp \
            geodatapointcreator.cpp \
            geodatapointrealcreator.cpp \
+           private/geodatapoint_coordinateseditor.cpp \
+           private/geodatapoint_editcoordinatescommand.cpp \
            private/geodatapoint_finishpointdefinitioncommand.cpp
-           private/geodatapolyline_removevertexcommand.cpp
 TRANSLATIONS += languages/iricGdPoint_ar_EG.ts \
                 languages/iricGdPoint_bg_BG.ts \
                 languages/iricGdPoint_bs_BA.ts \

--- a/libs/geodata/point/private/geodatapoint_coordinateseditor.cpp
+++ b/libs/geodata/point/private/geodatapoint_coordinateseditor.cpp
@@ -20,8 +20,9 @@ void GeoDataPoint::CoordinatesEditor::edit(GeoDataPoint* point)
 	QPointF p = point->point();
 	std::vector<QPointF> coords;
 	coords.push_back(p);
+	auto coords2 = applyOffset(coords);
 
-	CoordinatesEdit::edit(coords, point->preProcessorWindow(),
+	CoordinatesEdit::edit(coords2, point->preProcessorWindow(),
 												acceptCallback,
 												rejectCallback,
 												applyCallback,

--- a/libs/geodata/point/private/geodatapoint_coordinateseditor.cpp
+++ b/libs/geodata/point/private/geodatapoint_coordinateseditor.cpp
@@ -1,0 +1,76 @@
+#include "geodatapoint_coordinateseditor.h"
+#include "geodatapoint_editcoordinatescommand.h"
+
+#include <guibase/coordinates/coordinatesedit.h>
+#include <guicore/base/iricmainwindowinterface.h>
+#include <guicore/pre/base/preprocessorwindowinterface.h>
+#include <misc/iricundostack.h>
+
+GeoDataPoint* GeoDataPoint::CoordinatesEditor::targetPoint = nullptr;
+bool GeoDataPoint::CoordinatesEditor::applied = false;
+
+void GeoDataPoint::CoordinatesEditor::edit(GeoDataPoint* point)
+{
+	point->setMouseEventMode(meEditCoordinatesDialog);
+	point->iricMainWindow()->enterModelessDialogMode();
+
+	targetPoint = point;
+	applied = false;
+
+	QPointF p = point->point();
+	std::vector<QPointF> coords;
+	coords.push_back(p);
+
+	CoordinatesEdit::edit(coords, point->preProcessorWindow(),
+												acceptCallback,
+												rejectCallback,
+												applyCallback,
+												GeoDataPoint::tr("Point Coordinates"));
+}
+
+void GeoDataPoint::CoordinatesEditor::acceptCallback(const std::vector<QPointF>& coords)
+{
+	if (applied) {
+		// undo the older action
+		iRICUndoStack::instance().undo();
+	}
+	auto coords2 = unapplyOffset(coords);
+
+	iRICUndoStack::instance().push(new GeoDataPoint::EditCoordinatesCommand(false, coords2.at(0), targetPoint));
+
+	targetPoint->restoreMouseEventMode();
+	targetPoint->iricMainWindow()->exitModelessDialogMode();
+}
+
+void GeoDataPoint::CoordinatesEditor::rejectCallback()
+{
+	if (applied) {
+		// undo the older action
+		iRICUndoStack::instance().undo();
+		targetPoint->renderGraphicsView();
+	}
+	targetPoint->restoreMouseEventMode();
+	targetPoint->iricMainWindow()->exitModelessDialogMode();
+}
+
+void GeoDataPoint::CoordinatesEditor::applyCallback(const std::vector<QPointF>& coords)
+{
+	if (applied) {
+		// undo the older action
+		iRICUndoStack::instance().undo();
+	}
+	auto coords2 = unapplyOffset(coords);
+	iRICUndoStack::instance().push(new GeoDataPoint::EditCoordinatesCommand(true, coords2.at(0), targetPoint));
+
+	applied = true;
+}
+
+std::vector<QPointF> GeoDataPoint::CoordinatesEditor::applyOffset(const std::vector<QPointF>& coords)
+{
+	return CoordinatesEdit::applyOffset(coords, targetPoint->offset());
+}
+
+std::vector<QPointF> GeoDataPoint::CoordinatesEditor::unapplyOffset(const std::vector<QPointF>& coords)
+{
+	return CoordinatesEdit::unapplyOffset(coords, targetPoint->offset());
+}

--- a/libs/geodata/point/private/geodatapoint_coordinateseditor.h
+++ b/libs/geodata/point/private/geodatapoint_coordinateseditor.h
@@ -1,0 +1,22 @@
+#ifndef GEODATAPOINT_COORDINATESEDITOR_H
+#define GEODATAPOINT_COORDINATESEDITOR_H
+
+#include "../geodatapoint.h"
+
+class GeoDataPoint::CoordinatesEditor
+{
+public:
+	static void edit(GeoDataPoint* point);
+
+private:
+	static void acceptCallback(const std::vector<QPointF>& coords);
+	static void rejectCallback();
+	static void applyCallback(const std::vector<QPointF>& coords);
+	static std::vector<QPointF> applyOffset(const std::vector<QPointF>& coords);
+	static std::vector<QPointF> unapplyOffset(const std::vector<QPointF>& coords);
+
+	static GeoDataPoint* targetPoint;
+	static bool applied;
+};
+
+#endif // GEODATAPOINT_COORDINATESEDITOR_H

--- a/libs/geodata/point/private/geodatapoint_editcoordinatescommand.cpp
+++ b/libs/geodata/point/private/geodatapoint_editcoordinatescommand.cpp
@@ -1,0 +1,30 @@
+#include "geodatapoint_editcoordinatescommand.h"
+
+GeoDataPoint::EditCoordinatesCommand::EditCoordinatesCommand(bool apply, const QPointF& p, GeoDataPoint* point) :
+	QUndoCommand {GeoDataPoint::tr("Edit Point Coordinates")},
+	m_apply {apply},
+	m_newPoint {p},
+	m_point {point}
+{
+	m_oldPoint = point->point();
+}
+
+void GeoDataPoint::EditCoordinatesCommand::redo()
+{
+	applyCoords(m_newPoint);
+
+	m_point->renderGraphicsView();
+}
+
+void GeoDataPoint::EditCoordinatesCommand::undo()
+{
+	applyCoords(m_oldPoint);
+	if (m_apply) {return;}
+
+	m_point->renderGraphicsView();
+}
+
+void GeoDataPoint::EditCoordinatesCommand::applyCoords(const QPointF& point)
+{
+	m_point->setPoint(point);
+}

--- a/libs/geodata/point/private/geodatapoint_editcoordinatescommand.h
+++ b/libs/geodata/point/private/geodatapoint_editcoordinatescommand.h
@@ -1,0 +1,27 @@
+#ifndef GEODATAPOINT_EDITCOORDINATESCOMMAND_H
+#define GEODATAPOINT_EDITCOORDINATESCOMMAND_H
+
+#include "../geodatapoint.h"
+
+#include <QUndoCommand>
+
+class GeoDataPoint::EditCoordinatesCommand : public QUndoCommand
+{
+public:
+	EditCoordinatesCommand(bool apply, const QPointF& p, GeoDataPoint* point);
+
+	void redo() override;
+	void undo() override;
+
+private:
+	void applyCoords(const QPointF& point);
+
+	bool m_apply;
+
+	QPointF m_newPoint;
+	QPointF m_oldPoint;
+
+	GeoDataPoint* m_point;
+};
+
+#endif // GEODATAPOINT_EDITCOORDINATESCOMMAND_H

--- a/libs/geodata/pointgroup/geodatapointgroup.h
+++ b/libs/geodata/pointgroup/geodatapointgroup.h
@@ -43,6 +43,7 @@ private:
 	Impl* impl;
 
 public:
+	friend class GeoDataPointGroupCsvImporter;
 	friend class GeoDataPointGroupShpImporter;
 };
 

--- a/libs/geodata/pointgroup/geodatapointgroupcreator.cpp
+++ b/libs/geodata/pointgroup/geodatapointgroupcreator.cpp
@@ -1,5 +1,6 @@
 #include "geodatapointgroup.h"
 #include "geodatapointgroupcreator.h"
+#include "geodatapointgroupcsvexporter.h"
 #include "geodatapointgroupshpimporter.h"
 #include "geodatapointgroupshpexporter.h"
 
@@ -12,6 +13,7 @@ GeoDataPointGroupCreator::GeoDataPointGroupCreator(const QString& typeName) :
 {
 	importers().push_back(new GeoDataPointGroupShpImporter(this));
 	exporters().push_back(new GeoDataPointGroupShpExporter(this));
+	exporters().push_back(new GeoDataPointGroupCsvExporter(this));
 }
 
 QString GeoDataPointGroupCreator::name(unsigned int index) const

--- a/libs/geodata/pointgroup/geodatapointgroupcreator.cpp
+++ b/libs/geodata/pointgroup/geodatapointgroupcreator.cpp
@@ -1,8 +1,9 @@
 #include "geodatapointgroup.h"
 #include "geodatapointgroupcreator.h"
 #include "geodatapointgroupcsvexporter.h"
-#include "geodatapointgroupshpimporter.h"
+#include "geodatapointgroupcsvimporter.h"
 #include "geodatapointgroupshpexporter.h"
+#include "geodatapointgroupshpimporter.h"
 
 #include <guicore/pre/base/preprocessorgeodatadataiteminterface.h>
 
@@ -12,6 +13,7 @@ GeoDataPointGroupCreator::GeoDataPointGroupCreator(const QString& typeName) :
 	GeoDataPolyDataGroupCreator {typeName, tr("Point Group")}
 {
 	importers().push_back(new GeoDataPointGroupShpImporter(this));
+	importers().push_back(new GeoDataPointGroupCsvImporter(this));
 	exporters().push_back(new GeoDataPointGroupShpExporter(this));
 	exporters().push_back(new GeoDataPointGroupCsvExporter(this));
 }

--- a/libs/geodata/pointgroup/geodatapointgroupcsvexporter.cpp
+++ b/libs/geodata/pointgroup/geodatapointgroupcsvexporter.cpp
@@ -1,0 +1,62 @@
+#include "geodatapointgroup.h"
+#include "geodatapointgrouppoint.h"
+#include "geodatapointgroupcsvexporter.h"
+
+#include <guicore/project/projectdata.h>
+#include <guicore/project/projectmainfile.h>
+
+#include <QDir>
+#include <QFile>
+#include <QMessageBox>
+#include <QTextStream>
+
+GeoDataPointGroupCsvExporter::GeoDataPointGroupCsvExporter(GeoDataCreator* creator) :
+	GeoDataExporter {tr("CSV file"), creator}
+{}
+
+bool GeoDataPointGroupCsvExporter::doExport(GeoData* data, const QString& filename, const QString& /*selectedFilter*/, QWidget* w, ProjectData* pd)
+{
+	auto group = dynamic_cast<GeoDataPointGroup*>(data);
+	group->mergeEditTargetData();
+
+	QFile file(filename);
+	if (! file.open(QIODevice::WriteOnly | QIODevice::Text)) {
+		QMessageBox::critical(w, tr("Error"), tr("Error occured while exporting to %1.").arg(QDir::toNativeSeparators(filename)));
+		return false;
+	}
+	QTextStream stream(&file);
+	stream.setRealNumberNotation(QTextStream::FixedNotation);
+	stream.setRealNumberPrecision(3);
+	stream.setCodec("UTF-8");
+	// write header
+	bool isRef = data->gridAttribute()->isReferenceInformation();
+	if (isRef) {
+		stream << "x,y,name" << endl;
+	} else {
+		stream << "x,y,name,value" << endl;
+	}
+
+	auto o = pd->mainfile()->offset();
+	// write data
+	for (auto d : group->allData()) {
+		auto p = dynamic_cast<GeoDataPointGroupPoint*> (d);
+		const auto point = p->point();
+		if (isRef) {
+			stream << point.x() + o.x() << "," << point.y() + o.y() << "," << p->name() << endl;
+		} else {
+			stream << point.x() + o.x() << "," << point.y() + o.y() << "," << p->name() << "," << p->value().toDouble() << endl;
+		}
+	}
+	file.close();
+
+	return true;
+}
+
+const QStringList GeoDataPointGroupCsvExporter::fileDialogFilters()
+{
+	QStringList ret;
+
+	ret << tr("CSV file (*.csv)");
+
+	return ret;
+}

--- a/libs/geodata/pointgroup/geodatapointgroupcsvexporter.h
+++ b/libs/geodata/pointgroup/geodatapointgroupcsvexporter.h
@@ -1,0 +1,19 @@
+#ifndef GEODATAPOINTGROUPCSVEXPORTER_H
+#define GEODATAPOINTGROUPCSVEXPORTER_H
+
+#include "gd_pointgroup_global.h"
+
+#include <guicore/pre/geodata/geodataexporter.h>
+
+class GeoDataPointGroupCsvExporter : public GeoDataExporter
+{
+	Q_OBJECT
+
+public:
+	GeoDataPointGroupCsvExporter(GeoDataCreator* creator);
+
+	bool doExport(GeoData* data, const QString& filename, const QString& selectedFilter, QWidget* w, ProjectData* pd) override;
+	const QStringList fileDialogFilters() override;
+};
+
+#endif // GEODATAPOINTGROUPCSVEXPORTER_H

--- a/libs/geodata/pointgroup/geodatapointgroupcsvimporter.cpp
+++ b/libs/geodata/pointgroup/geodatapointgroupcsvimporter.cpp
@@ -1,0 +1,127 @@
+#include "geodatapointgroup.h"
+#include "geodatapointgroupcsvimporter.h"
+#include "geodatapointgrouppoint.h"
+
+#include <QDir>
+#include <QFile>
+#include <QMessageBox>
+#include <QTextStream>
+
+GeoDataPointGroupCsvImporter::GeoDataPointGroupCsvImporter(GeoDataCreator* creator) :
+	GeoDataImporter {"csv_point_group", tr("CSV file (Points)"), creator}
+{}
+
+const QStringList GeoDataPointGroupCsvImporter::fileDialogFilters()
+{
+	QStringList ret;
+	ret.append(tr("CSV file (Points) (*.csv)"));
+	return ret;
+}
+
+const QStringList GeoDataPointGroupCsvImporter::acceptableExtensions()
+{
+	QStringList ret;
+	ret.append("csv");
+	return ret;
+}
+
+bool GeoDataPointGroupCsvImporter::importData(GeoData* data, int index, QWidget* w)
+{
+	auto group = dynamic_cast<GeoDataPointGroup*>(data);
+
+	QFile file(filename());
+	if (! file.open(QIODevice::ReadOnly | QIODevice::Text)) {
+		QMessageBox::critical(w, tr("Error"), tr("Error occured while opening %1").arg(QDir::toNativeSeparators(filename())));
+		return false;
+	}
+	QTextStream stream(&file);
+	stream.setCodec("UTF-8");
+	bool isRef = data->gridAttribute()->isReferenceInformation();
+
+	// check header
+	QString buffer;
+	bool ok = stream.readLineInto(&buffer);
+	if (! ok) {
+		QMessageBox::critical(w, tr("Error"), tr("Error occured while reading header line. Make sure the file is saved in UTF-8 encoding."));
+		return false;
+	}
+	auto frags = buffer.split(",");
+	QStringList headers;
+	headers << "x" << "y" << "name";
+	if (isRef) {
+		if (frags.size() < 3) {
+			QMessageBox::critical(w, tr("Error"), tr("Error occured while reading header line. Header should have 3 columns at least."));
+			return false;
+		}
+	} else {
+		if (frags.size() < 4) {
+			QMessageBox::critical(w, tr("Error"), tr("Error occured while reading header line. Header should have 4 columns at least."));
+			return false;
+		}
+		headers << "value";
+	}
+	for (int i = 0; i < headers.size(); ++i) {
+		QString f = frags.at(i).trimmed();
+		if (f != headers.at(i)) {
+			QMessageBox::critical(w, tr("Error"), tr("Error occured while reading header line. Column %1 should be \"%2\", but \"%3\" is given.").arg(i + 1).arg(headers.at(i)).arg(f));
+			return false;
+		}
+	}
+	int lineno = 2;
+	while (true) {
+		bool ok = stream.readLineInto(&buffer);
+		if (! ok) {
+			if (stream.atEnd()) {
+				// successfully read all data
+				group->setupDataItem();
+				group->updateAttributeBrowser(true);
+				group->updateVtkObjects();
+				group->updateIndex();
+				return true;
+			}
+			// error occured
+			QMessageBox::critical(w, tr("Error"), tr("Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.").arg(lineno));
+			return false;
+		}
+		auto frags = buffer.split(",");
+		if (isRef) {
+			if (frags.size() < 3) {
+				QMessageBox::critical(w, tr("Error"), tr("Error occured while reading line %1. Data should have 3 columns at least.").arg(lineno));
+				return false;
+			}
+		} else {
+			if (frags.size() < 4) {
+				QMessageBox::critical(w, tr("Error"), tr("Error occured while reading line %1. Data should have 4 columns at least.").arg(lineno));
+				return false;
+			}
+			headers << "value";
+		}
+		double x, y, value = 0;
+		QString name;
+		x = frags.at(0).toDouble(&ok);
+		if (! ok) {
+			QMessageBox::critical(w, tr("Error"), tr("Error occured while reading \"x\" value in line %1. \"x\" should be real value but \"%2\" is specified.").arg(lineno).arg(frags.at(0)));
+			return false;
+		}
+		y = frags.at(1).toDouble(&ok);
+		if (! ok) {
+			QMessageBox::critical(w, tr("Error"), tr("Error occured while reading \"y\" value in line %1. \"y\" should be real value but \"%2\" is specified.").arg(lineno).arg(frags.at(1)));
+			return false;
+		}
+		name = frags.at(2);
+		if (! isRef) {
+			value = frags.at(3).toDouble(&ok);
+			if (! ok) {
+				QMessageBox::critical(w, tr("Error"), tr("Error occured while reading \"value\" value in line %1. \"value\" should be real value but \"%2\" is specified.").arg(lineno).arg(frags.at(3)));
+				return false;
+			}
+		}
+		auto point = new GeoDataPointGroupPoint(QPointF(x, y), group);
+		point->setName(name);
+		point->setValue(value);
+
+		group->addData(point);
+
+		++ lineno;
+	}
+}

--- a/libs/geodata/pointgroup/geodatapointgroupcsvimporter.h
+++ b/libs/geodata/pointgroup/geodatapointgroupcsvimporter.h
@@ -1,0 +1,22 @@
+#ifndef GEODATAPOINTGROUPCSVIMPORTER_H
+#define GEODATAPOINTGROUPCSVIMPORTER_H
+
+#include <guicore/pre/geodata/geodataimporter.h>
+
+#include <QVariant>
+
+class GeoDataPointGroupCsvImporter : public GeoDataImporter
+{
+	Q_OBJECT
+
+public:
+	GeoDataPointGroupCsvImporter(GeoDataCreator* creator);
+
+	const QStringList fileDialogFilters() override;
+	const QStringList acceptableExtensions() override;
+
+	bool importData(GeoData* data, int index, QWidget* w) override;
+};
+
+
+#endif // GEODATAPOINTGROUPCSVIMPORTER_H

--- a/libs/geodata/pointgroup/geodatapointgrouppoint.cpp
+++ b/libs/geodata/pointgroup/geodatapointgrouppoint.cpp
@@ -87,5 +87,5 @@ void GeoDataPointGroupPoint::saveExternalData(QDataStream* stream)
 
 void GeoDataPointGroupPoint::applyOffset(double x, double y)
 {
-	setPoint(point() + QPointF(x, y));
+	setPoint(point() - QPointF(x, y));
 }

--- a/libs/geodata/pointgroup/geodatapointgroupshpexporter.cpp
+++ b/libs/geodata/pointgroup/geodatapointgroupshpexporter.cpp
@@ -91,8 +91,8 @@ SHPObject* GeoDataPointGroupShpExporter::getSHPObject(GeoDataPointGroupPoint* po
 
 	partStart[0] = 0;
 	nVertices = 1;
-	xlist.push_back(p.x());
-	ylist.push_back(p.y());
+	xlist.push_back(p.x() + xoffset);
+	ylist.push_back(p.y() + yoffset);
 
 	SHPObject* ret = SHPCreateObject(SHPT_POINT, index, nParts, partStart.data(), NULL, nVertices, xlist.data(), ylist.data(), NULL, NULL);
 	SHPComputeExtents(ret);

--- a/libs/geodata/pointgroup/languages/iricGdPointGroup_ar_EG.ts
+++ b/libs/geodata/pointgroup/languages/iricGdPointGroup_ar_EG.ts
@@ -36,6 +36,84 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPointGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPointGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Points)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Points) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPointGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/libs/geodata/pointgroup/languages/iricGdPointGroup_bg_BG.ts
+++ b/libs/geodata/pointgroup/languages/iricGdPointGroup_bg_BG.ts
@@ -36,6 +36,84 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPointGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPointGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Points)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Points) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPointGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/libs/geodata/pointgroup/languages/iricGdPointGroup_bs_BA.ts
+++ b/libs/geodata/pointgroup/languages/iricGdPointGroup_bs_BA.ts
@@ -36,6 +36,84 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPointGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPointGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Points)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Points) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPointGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/libs/geodata/pointgroup/languages/iricGdPointGroup_ca_ES.ts
+++ b/libs/geodata/pointgroup/languages/iricGdPointGroup_ca_ES.ts
@@ -36,6 +36,84 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPointGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPointGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Points)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Points) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPointGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/libs/geodata/pointgroup/languages/iricGdPointGroup_cs_CZ.ts
+++ b/libs/geodata/pointgroup/languages/iricGdPointGroup_cs_CZ.ts
@@ -36,6 +36,84 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPointGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPointGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Points)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Points) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPointGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/libs/geodata/pointgroup/languages/iricGdPointGroup_da_DK.ts
+++ b/libs/geodata/pointgroup/languages/iricGdPointGroup_da_DK.ts
@@ -36,6 +36,84 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPointGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPointGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Points)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Points) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPointGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/libs/geodata/pointgroup/languages/iricGdPointGroup_de_DE.ts
+++ b/libs/geodata/pointgroup/languages/iricGdPointGroup_de_DE.ts
@@ -36,6 +36,84 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPointGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPointGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Points)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Points) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPointGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/libs/geodata/pointgroup/languages/iricGdPointGroup_el_GR.ts
+++ b/libs/geodata/pointgroup/languages/iricGdPointGroup_el_GR.ts
@@ -36,6 +36,84 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPointGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPointGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Points)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Points) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPointGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/libs/geodata/pointgroup/languages/iricGdPointGroup_es_ES.ts
+++ b/libs/geodata/pointgroup/languages/iricGdPointGroup_es_ES.ts
@@ -36,6 +36,84 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPointGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPointGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Points)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Points) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPointGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/libs/geodata/pointgroup/languages/iricGdPointGroup_et_EE.ts
+++ b/libs/geodata/pointgroup/languages/iricGdPointGroup_et_EE.ts
@@ -36,6 +36,84 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPointGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPointGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Points)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Points) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPointGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/libs/geodata/pointgroup/languages/iricGdPointGroup_eu_ES.ts
+++ b/libs/geodata/pointgroup/languages/iricGdPointGroup_eu_ES.ts
@@ -36,6 +36,84 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPointGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPointGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Points)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Points) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPointGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/libs/geodata/pointgroup/languages/iricGdPointGroup_fi_FI.ts
+++ b/libs/geodata/pointgroup/languages/iricGdPointGroup_fi_FI.ts
@@ -36,6 +36,84 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPointGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPointGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Points)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Points) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPointGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/libs/geodata/pointgroup/languages/iricGdPointGroup_fr_FR.ts
+++ b/libs/geodata/pointgroup/languages/iricGdPointGroup_fr_FR.ts
@@ -36,6 +36,84 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPointGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPointGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Points)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Points) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPointGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/libs/geodata/pointgroup/languages/iricGdPointGroup_gl_ES.ts
+++ b/libs/geodata/pointgroup/languages/iricGdPointGroup_gl_ES.ts
@@ -36,6 +36,84 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPointGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPointGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Points)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Points) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPointGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/libs/geodata/pointgroup/languages/iricGdPointGroup_hi_IN.ts
+++ b/libs/geodata/pointgroup/languages/iricGdPointGroup_hi_IN.ts
@@ -36,6 +36,84 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPointGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPointGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Points)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Points) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPointGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/libs/geodata/pointgroup/languages/iricGdPointGroup_hu_HU.ts
+++ b/libs/geodata/pointgroup/languages/iricGdPointGroup_hu_HU.ts
@@ -36,6 +36,84 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPointGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPointGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Points)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Points) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPointGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/libs/geodata/pointgroup/languages/iricGdPointGroup_id_ID.ts
+++ b/libs/geodata/pointgroup/languages/iricGdPointGroup_id_ID.ts
@@ -36,6 +36,84 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPointGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPointGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Points)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Points) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPointGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/libs/geodata/pointgroup/languages/iricGdPointGroup_is_IS.ts
+++ b/libs/geodata/pointgroup/languages/iricGdPointGroup_is_IS.ts
@@ -36,6 +36,84 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPointGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPointGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Points)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Points) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPointGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/libs/geodata/pointgroup/languages/iricGdPointGroup_it_IT.ts
+++ b/libs/geodata/pointgroup/languages/iricGdPointGroup_it_IT.ts
@@ -36,6 +36,84 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPointGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPointGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Points)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Points) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPointGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/libs/geodata/pointgroup/languages/iricGdPointGroup_ja_JP.ts
+++ b/libs/geodata/pointgroup/languages/iricGdPointGroup_ja_JP.ts
@@ -44,6 +44,84 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPointGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation>CSV ファイル</translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation>エラー</translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation>%1 へのエクスポートでエラーが発生しました。</translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation>CSV ファイル (*.csv)</translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPointGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Points)</source>
+        <translation>CSV ファイル (点)</translation>
+    </message>
+    <message>
+        <source>CSV file (Points) (*.csv)</source>
+        <translation>CSV ファイル (点) (*.csv)</translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation>エラー</translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation>%1 を開けませんでした。</translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation>ヘッダ行の読み込み中にエラーが発生しました。UTF-8 エンコーディングで保存されているか確認してください。</translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 3 columns at least.</source>
+        <translation>ヘッダ行の読み込み中にエラーが発生しました。ヘッダには3列以上データがなくてはいけません。</translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 4 columns at least.</source>
+        <translation>ヘッダ行の読み込み中にエラーが発生しました。ヘッダには4列以上データがなくてはいけません。</translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation>ヘッダ行の読み込み中にエラーが発生しました。%1 列目の値は &quot;%2&quot; のはずですが、&quot;%3&quot; が指定されています。</translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation>%1行目の読み込み中にエラーが発生しました。UTF-8 エンコーディングで保存されているか確認してください。</translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 3 columns at least.</source>
+        <translation>%1行目の読み込み中にエラーが発生しました。3列以上データがなくてはいけません。</translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 4 columns at least.</source>
+        <translation>%1行目の読み込み中にエラーが発生しました。4列以上データがなくてはいけません。</translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation>%1行目の &quot;x&quot; の読み込み中にエラーが発生しました。 &quot;x&quot; は実数値でなくてはいけませんが、 &quot;%2&quot; が指定されました。</translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation>%1行目の &quot;y&quot; の読み込み中にエラーが発生しました。 &quot;y&quot; は実数値でなくてはいけませんが、 &quot;%2&quot; が指定されました。</translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation>%1行目の &quot;value&quot; の読み込み中にエラーが発生しました。 &quot;value&quot; は実数値でなくてはいけませんが、 &quot;%2&quot; が指定されました。</translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPointGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/libs/geodata/pointgroup/languages/iricGdPointGroup_ko_KR.ts
+++ b/libs/geodata/pointgroup/languages/iricGdPointGroup_ko_KR.ts
@@ -36,6 +36,84 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPointGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPointGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Points)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Points) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPointGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/libs/geodata/pointgroup/languages/iricGdPointGroup_ky_KG.ts
+++ b/libs/geodata/pointgroup/languages/iricGdPointGroup_ky_KG.ts
@@ -36,6 +36,84 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPointGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPointGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Points)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Points) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPointGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/libs/geodata/pointgroup/languages/iricGdPointGroup_lt_LT.ts
+++ b/libs/geodata/pointgroup/languages/iricGdPointGroup_lt_LT.ts
@@ -36,6 +36,84 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPointGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPointGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Points)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Points) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPointGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/libs/geodata/pointgroup/languages/iricGdPointGroup_lv_LV.ts
+++ b/libs/geodata/pointgroup/languages/iricGdPointGroup_lv_LV.ts
@@ -36,6 +36,84 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPointGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPointGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Points)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Points) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPointGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/libs/geodata/pointgroup/languages/iricGdPointGroup_nb_NO.ts
+++ b/libs/geodata/pointgroup/languages/iricGdPointGroup_nb_NO.ts
@@ -36,6 +36,84 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPointGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPointGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Points)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Points) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPointGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/libs/geodata/pointgroup/languages/iricGdPointGroup_nl_NL.ts
+++ b/libs/geodata/pointgroup/languages/iricGdPointGroup_nl_NL.ts
@@ -36,6 +36,84 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPointGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPointGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Points)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Points) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPointGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/libs/geodata/pointgroup/languages/iricGdPointGroup_pl_PL.ts
+++ b/libs/geodata/pointgroup/languages/iricGdPointGroup_pl_PL.ts
@@ -36,6 +36,84 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPointGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPointGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Points)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Points) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPointGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/libs/geodata/pointgroup/languages/iricGdPointGroup_pt_BR.ts
+++ b/libs/geodata/pointgroup/languages/iricGdPointGroup_pt_BR.ts
@@ -36,6 +36,84 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPointGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPointGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Points)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Points) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPointGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/libs/geodata/pointgroup/languages/iricGdPointGroup_pt_PT.ts
+++ b/libs/geodata/pointgroup/languages/iricGdPointGroup_pt_PT.ts
@@ -36,6 +36,84 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPointGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPointGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Points)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Points) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPointGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/libs/geodata/pointgroup/languages/iricGdPointGroup_ro_RO.ts
+++ b/libs/geodata/pointgroup/languages/iricGdPointGroup_ro_RO.ts
@@ -36,6 +36,84 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPointGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPointGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Points)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Points) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPointGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/libs/geodata/pointgroup/languages/iricGdPointGroup_ru_RU.ts
+++ b/libs/geodata/pointgroup/languages/iricGdPointGroup_ru_RU.ts
@@ -36,6 +36,84 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPointGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPointGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Points)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Points) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPointGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/libs/geodata/pointgroup/languages/iricGdPointGroup_sl_SI.ts
+++ b/libs/geodata/pointgroup/languages/iricGdPointGroup_sl_SI.ts
@@ -36,6 +36,84 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPointGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPointGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Points)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Points) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPointGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/libs/geodata/pointgroup/languages/iricGdPointGroup_sv_SE.ts
+++ b/libs/geodata/pointgroup/languages/iricGdPointGroup_sv_SE.ts
@@ -36,6 +36,84 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPointGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPointGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Points)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Points) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPointGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/libs/geodata/pointgroup/languages/iricGdPointGroup_th_TH.ts
+++ b/libs/geodata/pointgroup/languages/iricGdPointGroup_th_TH.ts
@@ -36,6 +36,84 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPointGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPointGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Points)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Points) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPointGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/libs/geodata/pointgroup/languages/iricGdPointGroup_tr_TR.ts
+++ b/libs/geodata/pointgroup/languages/iricGdPointGroup_tr_TR.ts
@@ -36,6 +36,84 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPointGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPointGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Points)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Points) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPointGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/libs/geodata/pointgroup/languages/iricGdPointGroup_uk_UA.ts
+++ b/libs/geodata/pointgroup/languages/iricGdPointGroup_uk_UA.ts
@@ -36,6 +36,84 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPointGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPointGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Points)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Points) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPointGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/libs/geodata/pointgroup/languages/iricGdPointGroup_vi_VN.ts
+++ b/libs/geodata/pointgroup/languages/iricGdPointGroup_vi_VN.ts
@@ -36,6 +36,84 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPointGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPointGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Points)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Points) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPointGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/libs/geodata/pointgroup/languages/iricGdPointGroup_zh_CN.ts
+++ b/libs/geodata/pointgroup/languages/iricGdPointGroup_zh_CN.ts
@@ -36,6 +36,84 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPointGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPointGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Points)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Points) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPointGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/libs/geodata/pointgroup/languages/iricGdPointGroup_zh_TW.ts
+++ b/libs/geodata/pointgroup/languages/iricGdPointGroup_zh_TW.ts
@@ -36,6 +36,84 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPointGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPointGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Points)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Points) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 3 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 4 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPointGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/libs/geodata/pointgroup/pointgroup.pro
+++ b/libs/geodata/pointgroup/pointgroup.pro
@@ -144,6 +144,7 @@ HEADERS += gd_pointgroup_global.h \
            geodatapointgroupcellmappert.h \
            geodatapointgroupcreator.h \
            geodatapointgroupcreatort.h \
+           geodatapointgroupcsvexporter.h \
            geodatapointgroupintegercreator.h \
            geodatapointgroupnodemappert.h \
            geodatapointgrouppoint.h \
@@ -158,6 +159,7 @@ HEADERS += gd_pointgroup_global.h \
 FORMS +=
 SOURCES += geodatapointgroup.cpp \
            geodatapointgroupcreator.cpp \
+           geodatapointgroupcsvexporter.cpp \
            geodatapointgroupintegercreator.cpp \
            geodatapointgrouppoint.cpp \
            geodatapointgrouprealcreator.cpp \

--- a/libs/geodata/pointgroup/pointgroup.pro
+++ b/libs/geodata/pointgroup/pointgroup.pro
@@ -145,6 +145,7 @@ HEADERS += gd_pointgroup_global.h \
            geodatapointgroupcreator.h \
            geodatapointgroupcreatort.h \
            geodatapointgroupcsvexporter.h \
+           geodatapointgroupcsvimporter.h \
            geodatapointgroupintegercreator.h \
            geodatapointgroupnodemappert.h \
            geodatapointgrouppoint.h \
@@ -160,6 +161,7 @@ FORMS +=
 SOURCES += geodatapointgroup.cpp \
            geodatapointgroupcreator.cpp \
            geodatapointgroupcsvexporter.cpp \
+           geodatapointgroupcsvimporter.cpp \
            geodatapointgroupintegercreator.cpp \
            geodatapointgrouppoint.cpp \
            geodatapointgrouprealcreator.cpp \

--- a/libs/geodata/polydatagroup/geodatapolydatagroup.cpp
+++ b/libs/geodata/polydatagroup/geodatapolydatagroup.cpp
@@ -931,6 +931,10 @@ void GeoDataPolyDataGroup::doApplyOffset(double x, double y)
 	for (auto d : impl->m_data) {
 		d->applyOffset(x, y);
 	}
+	if (impl->m_editTargetData != nullptr) {
+		impl->m_editTargetData->applyOffset(x, y);
+	}
+
 	updateVtkObjects();
 	updateSelectedDataVtkObjects();
 	updateIndex();

--- a/libs/geodata/polygon/geodatapolygon.cpp
+++ b/libs/geodata/polygon/geodatapolygon.cpp
@@ -1335,7 +1335,7 @@ int GeoDataPolygon::iRICLibType() const
 
 void GeoDataPolygon::applyOffsetToAbstractPolygon(GeoDataPolygonAbstractPolygon* polygon, double x, double y)
 {
-	QPolygonF pol = polygon->polygon(QPointF(x, y));
+	QPolygonF pol = polygon->polygon(QPointF(- x, - y));
 	polygon->setPolygon(pol);
 }
 

--- a/libs/geodata/polygongroup/geodatapolygongroup.cpp
+++ b/libs/geodata/polygongroup/geodatapolygongroup.cpp
@@ -168,7 +168,10 @@ void GeoDataPolygonGroup::updateSelectedDataVtkObjects()
 	auto pointValues = vtkSmartPointer<vtkDoubleArray>::New();
 	pointValues->SetName(VALUE.c_str());
 
-	for (auto d : selectedData()) {
+	auto sData = selectedData();
+	if (sData.size() == 0) {return;}
+
+	for (auto d : sData) {
 		auto pol = dynamic_cast<GeoDataPolygonGroupPolygon*> (d);
 		double v = pol->value().toDouble();
 		auto offset = pol->indexOffset();
@@ -186,6 +189,7 @@ void GeoDataPolygonGroup::updateSelectedDataVtkObjects()
 			edgeValues->InsertNextValue(v);
 		}
 	}
+
 	impl->m_selectedPolygonsPointsPolyData->SetPoints(impl->m_points);
 	impl->m_selectedPolygonsPointsPolyData->SetVerts(points);
 	impl->m_selectedPolygonsPointsPolyData->GetCellData()->AddArray(pointValues);

--- a/libs/geodata/polygongroup/geodatapolygongroup.cpp
+++ b/libs/geodata/polygongroup/geodatapolygongroup.cpp
@@ -34,10 +34,12 @@ std::string VALUE = "value";
 
 } // namespace
 
-GeoDataPolygonGroup::GeoDataPolygonGroup(ProjectDataItem* d, GeoDataCreator* creator, SolverDefinitionGridAttribute* condition) :
-	GeoDataPolyDataGroup(d, creator, condition),
+GeoDataPolygonGroup::GeoDataPolygonGroup(ProjectDataItem* d, GeoDataCreator* gdcreator, SolverDefinitionGridAttribute* condition) :
+	GeoDataPolyDataGroup(d, gdcreator, condition),
 	impl {new Impl {this}}
 {
+	addAction()->setText(tr("&Add New %1...").arg(creator()->shapeNameCamelCase()));
+
 	ScalarsToColorsContainer* stcc = scalarsToColorsContainer();
 	if (stcc != nullptr) {
 		auto mapper = impl->m_paintActor->GetMapper();

--- a/libs/geodata/polygongroup/geodatapolygongroup.h
+++ b/libs/geodata/polygongroup/geodatapolygongroup.h
@@ -44,6 +44,7 @@ private:
 
 public:
 	friend class GeoDataPolygonGroupAttributeBrowser;
+	friend class GeoDataPolygonGroupCsvImporter;
 	friend class GeoDataPolygonGroupShpImporter;
 };
 

--- a/libs/geodata/polygongroup/geodatapolygongroupcreator.cpp
+++ b/libs/geodata/polygongroup/geodatapolygongroupcreator.cpp
@@ -1,5 +1,6 @@
 #include "geodatapolygongroup.h"
 #include "geodatapolygongroupcreator.h"
+#include "geodatapolygongroupcsvexporter.h"
 #include "geodatapolygongroupshpimporter.h"
 #include "geodatapolygongroupshpexporter.h"
 
@@ -10,6 +11,7 @@ GeoDataPolygonGroupCreator::GeoDataPolygonGroupCreator(const QString& typeName) 
 {
 	importers().push_back(new GeoDataPolygonGroupShpImporter(this));
 	exporters().push_back(new GeoDataPolygonGroupShpExporter(this));
+	exporters().push_back(new GeoDataPolygonGroupCsvExporter(this));
 }
 
 QString GeoDataPolygonGroupCreator::name(unsigned int index) const

--- a/libs/geodata/polygongroup/geodatapolygongroupcreator.cpp
+++ b/libs/geodata/polygongroup/geodatapolygongroupcreator.cpp
@@ -1,8 +1,9 @@
 #include "geodatapolygongroup.h"
 #include "geodatapolygongroupcreator.h"
 #include "geodatapolygongroupcsvexporter.h"
-#include "geodatapolygongroupshpimporter.h"
+#include "geodatapolygongroupcsvimporter.h"
 #include "geodatapolygongroupshpexporter.h"
+#include "geodatapolygongroupshpimporter.h"
 
 #include <shapefil.h>
 
@@ -10,6 +11,7 @@ GeoDataPolygonGroupCreator::GeoDataPolygonGroupCreator(const QString& typeName) 
 	GeoDataPolyDataGroupCreator {typeName, tr("Polygon Group")}
 {
 	importers().push_back(new GeoDataPolygonGroupShpImporter(this));
+	importers().push_back(new GeoDataPolygonGroupCsvImporter(this));
 	exporters().push_back(new GeoDataPolygonGroupShpExporter(this));
 	exporters().push_back(new GeoDataPolygonGroupCsvExporter(this));
 }

--- a/libs/geodata/polygongroup/geodatapolygongroupcsvexporter.cpp
+++ b/libs/geodata/polygongroup/geodatapolygongroupcsvexporter.cpp
@@ -1,0 +1,82 @@
+#include "geodatapolygongroup.h"
+#include "geodatapolygongrouppolygon.h"
+#include "geodatapolygongroupcsvexporter.h"
+
+#include <guicore/project/projectdata.h>
+#include <guicore/project/projectmainfile.h>
+#include <misc/informationdialog.h>
+
+#include <geos/geom/LineString.h>
+#include <geos/geom/Point.h>
+#include <geos/geom/Polygon.h>
+
+#include <QDir>
+#include <QFile>
+#include <QMessageBox>
+#include <QTextStream>
+
+GeoDataPolygonGroupCsvExporter::GeoDataPolygonGroupCsvExporter(GeoDataCreator* creator) :
+	GeoDataExporter {tr("CSV file"), creator}
+{}
+
+bool GeoDataPolygonGroupCsvExporter::doExport(GeoData* data, const QString& filename, const QString& /*selectedFilter*/, QWidget* w, ProjectData* pd)
+{
+	auto group = dynamic_cast<GeoDataPolygonGroup*>(data);
+	group->mergeEditTargetData();
+
+	QFile file(filename);
+	if (! file.open(QIODevice::WriteOnly | QIODevice::Text)) {
+		QMessageBox::critical(w, tr("Error"), tr("Error occured while exporting to %1.").arg(QDir::toNativeSeparators(filename)));
+		return false;
+	}
+	QTextStream stream(&file);
+	stream.setRealNumberNotation(QTextStream::FixedNotation);
+	stream.setRealNumberPrecision(3);
+	stream.setCodec("UTF-8");
+	// write header
+	bool isRef = data->gridAttribute()->isReferenceInformation();
+	if (isRef) {
+		stream << "pid,vid,x,y,name" << endl;
+	} else {
+		stream << "pid,vid,x,y,name,value" << endl;
+	}
+
+	auto o = pd->mainfile()->offset();
+	// write data
+	int lid = 1;
+	bool holeExists = false;
+	for (auto d : group->allData()) {
+		auto p = dynamic_cast<GeoDataPolygonGroupPolygon*> (d);
+		auto polygon = p->geosPolygon();
+		auto ring = polygon->getExteriorRing();
+		auto pid = 1;
+		for (std::size_t i = 0; i < ring->getNumPoints(); ++i) {
+			auto point = ring->getPointN(i);
+			if (isRef) {
+				stream << lid << "," << pid << "," << point->getX() + o.x() << "," << point->getY() + o.y() << "," << p->name() << endl;
+			} else {
+				stream << lid << "," << pid << "," << point->getX() + o.x() << "," << point->getY() + o.y() << "," << p->name() << "," << p->value().toDouble() << endl;
+			}
+			++ pid;
+		}
+		++ lid;
+
+		holeExists = holeExists || (polygon->getNumInteriorRing() > 0);
+	}
+	file.close();
+
+	if (holeExists) {
+		InformationDialog::warning(w, tr("Warning"), tr("Some polygon in this polygon group has holes, but holes are not exported to CSV file. If you want to export holes, please export to ESRI Shapefile."), "polygongroup_csv_export_hole");
+	}
+
+	return true;
+}
+
+const QStringList GeoDataPolygonGroupCsvExporter::fileDialogFilters()
+{
+	QStringList ret;
+
+	ret << tr("CSV file (*.csv)");
+
+	return ret;
+}

--- a/libs/geodata/polygongroup/geodatapolygongroupcsvexporter.h
+++ b/libs/geodata/polygongroup/geodatapolygongroupcsvexporter.h
@@ -1,0 +1,17 @@
+#ifndef GEODATAPOLYGONGROUPCSVEXPORTER_H
+#define GEODATAPOLYGONGROUPCSVEXPORTER_H
+
+#include <guicore/pre/geodata/geodataexporter.h>
+
+class GeoDataPolygonGroupCsvExporter : public GeoDataExporter
+{
+	Q_OBJECT
+
+public:
+	GeoDataPolygonGroupCsvExporter(GeoDataCreator* creator);
+
+	bool doExport(GeoData* data, const QString& filename, const QString& selectedFilter, QWidget* w, ProjectData* pd) override;
+	const QStringList fileDialogFilters() override;
+};
+
+#endif // GEODATAPOLYGONGROUPCSVEXPORTER_H

--- a/libs/geodata/polygongroup/geodatapolygongroupcsvimporter.cpp
+++ b/libs/geodata/polygongroup/geodatapolygongroupcsvimporter.cpp
@@ -1,0 +1,200 @@
+#include "geodatapolygongroup.h"
+#include "geodatapolygongroupcsvimporter.h"
+#include "geodatapolygongrouppolygon.h"
+
+#include <QDir>
+#include <QFile>
+#include <QMessageBox>
+#include <QPolygonF>
+#include <QTextStream>
+
+namespace {
+
+void addNewPolygon(GeoDataPolygonGroup* group, const QString& name, double value, QPolygonF polygon)
+{
+	if (polygon.at(0) != polygon.at(polygon.size() - 1)) {
+		polygon.append(polygon.at(0));
+	}
+
+	std::vector<QPolygonF> holes;
+	auto newLine = new GeoDataPolygonGroupPolygon(polygon, holes, group);
+	newLine->setName(name);
+	newLine->setValue(value);
+	group->addData(newLine);
+}
+
+} // namespace
+
+GeoDataPolygonGroupCsvImporter::GeoDataPolygonGroupCsvImporter(GeoDataCreator* creator) :
+	GeoDataImporter {"csv_polygon_group", tr("CSV file (Polygons)"), creator}
+{}
+
+const QStringList GeoDataPolygonGroupCsvImporter::fileDialogFilters()
+{
+	QStringList ret;
+	ret.append(tr("CSV file (Polygons) (*.csv)"));
+	return ret;
+}
+
+const QStringList GeoDataPolygonGroupCsvImporter::acceptableExtensions()
+{
+	QStringList ret;
+	ret.append("csv");
+	return ret;
+}
+
+bool GeoDataPolygonGroupCsvImporter::importData(GeoData* data, int index, QWidget* w)
+{
+	auto group = dynamic_cast<GeoDataPolygonGroup*>(data);
+
+	QFile file(filename());
+	if (! file.open(QIODevice::ReadOnly | QIODevice::Text)) {
+		QMessageBox::critical(w, tr("Error"), tr("Error occured while opening %1").arg(QDir::toNativeSeparators(filename())));
+		return false;
+	}
+	QTextStream stream(&file);
+	stream.setCodec("UTF-8");
+	bool isRef = data->gridAttribute()->isReferenceInformation();
+
+	// check header
+	QString buffer;
+	bool ok = stream.readLineInto(&buffer);
+	if (! ok) {
+		QMessageBox::critical(w, tr("Error"), tr("Error occured while reading header line. Make sure the file is saved in UTF-8 encoding."));
+		return false;
+	}
+	auto frags = buffer.split(",");
+	QStringList headers;
+	headers << "pid" << "vid" << "x" << "y" << "name";
+	if (isRef) {
+		if (frags.size() < 5) {
+			QMessageBox::critical(w, tr("Error"), tr("Error occured while reading header line. Header should have 5 columns at least."));
+			return false;
+		}
+	} else {
+		if (frags.size() < 6) {
+			QMessageBox::critical(w, tr("Error"), tr("Error occured while reading header line. Header should have 6 columns at least."));
+			return false;
+		}
+		headers << "value";
+	}
+	for (int i = 0; i < headers.size(); ++i) {
+		QString f = frags.at(i).trimmed();
+		if (f != headers.at(i)) {
+			QMessageBox::critical(w, tr("Error"), tr("Error occured while reading header line. Column %1 should be \"%2\", but \"%3\" is given.").arg(i + 1).arg(headers.at(i)).arg(f));
+			return false;
+		}
+	}
+	int lineno = 2;
+
+	int currentPid = 0;
+	QString currentName;
+	double currentValue = 0;
+	QPolygonF polygon;
+
+	while (true) {
+		bool ok = stream.readLineInto(&buffer);
+		if (! ok) {
+			if (stream.atEnd()) {
+				if (polygon.size() == 0) {
+					QMessageBox::critical(w, tr("Error"), tr("Error occured while reading line %1. There is no data.").arg(lineno - 1));
+					return false;
+				}
+
+				if (polygon.size() < 3) {
+					QMessageBox::critical(w, tr("Error"), tr("Error occured while reading line %1. Polygon should have three points at least.").arg(lineno - 1));
+					return false;
+				}
+				addNewPolygon(group, currentName, currentValue, polygon);
+				// successfully read all data
+				group->setupDataItem();
+				group->updateAttributeBrowser(true);
+				group->updateVtkObjects();
+				group->updateIndex();
+				return true;
+			}
+			// error occured
+			QMessageBox::critical(w, tr("Error"), tr("Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.").arg(lineno));
+			return false;
+		}
+		auto frags = buffer.split(",");
+		if (isRef) {
+			if (frags.size() < 5) {
+				QMessageBox::critical(w, tr("Error"), tr("Error occured while reading line %1. Data should have 5 columns at least.").arg(lineno));
+				return false;
+			}
+		} else {
+			if (frags.size() < 6) {
+				QMessageBox::critical(w, tr("Error"), tr("Error occured while reading line %1. Data should have 6 columns at least.").arg(lineno));
+				return false;
+			}
+			headers << "value";
+		}
+		int pid, vid;
+		double x, y, value = 0;
+		QString name;
+
+		pid = frags.at(0).toInt(&ok);
+		if (! ok) {
+			QMessageBox::critical(w, tr("Error"), tr("Error occured while reading \"pid\" value in line %1. \"pid\" should be integer value but \"%2\" is specified.").arg(lineno).arg(frags.at(0)));
+			return false;
+		}
+		vid = frags.at(1).toInt(&ok);
+		if (! ok) {
+			QMessageBox::critical(w, tr("Error"), tr("Error occured while reading \"vid\" value in line %1. \"vid\" should be integer value but \"%2\" is specified.").arg(lineno).arg(frags.at(1)));
+			return false;
+		}
+		x = frags.at(2).toDouble(&ok);
+		if (! ok) {
+			QMessageBox::critical(w, tr("Error"), tr("Error occured while reading \"x\" value in line %1. \"x\" should be real value but \"%2\" is specified.").arg(lineno).arg(frags.at(2)));
+			return false;
+		}
+		y = frags.at(3).toDouble(&ok);
+		if (! ok) {
+			QMessageBox::critical(w, tr("Error"), tr("Error occured while reading \"y\" value in line %1. \"y\" should be real value but \"%2\" is specified.").arg(lineno).arg(frags.at(3)));
+			return false;
+		}
+		name = frags.at(4);
+		if (! isRef) {
+			value = frags.at(5).toDouble(&ok);
+			if (! ok) {
+				QMessageBox::critical(w, tr("Error"), tr("Error occured while reading \"value\" value in line %1. \"value\" should be real value but \"%2\" is specified.").arg(lineno).arg(frags.at(5)));
+				return false;
+			}
+		}
+		if (polygon.size() == 0) {
+			// this is the first data
+			currentPid = pid;
+			currentName = name;
+			currentValue = value;
+			polygon.push_back(QPointF(x, y));
+		} else {
+			if (pid != currentPid) {
+				// old line finished
+				if (polygon.size() < 3) {
+					QMessageBox::critical(w, tr("Error"), tr("Error occured while reading line %1. Polygon should have three points at least.").arg(lineno - 1));
+					return false;
+				}
+				addNewPolygon(group, currentName, currentValue, polygon);
+
+				currentPid = pid;
+				currentName = name;
+				currentValue = value;
+				polygon.clear();
+				polygon.push_back(QPointF(x, y));
+			} else {
+				if (currentName != name) {
+					QMessageBox::critical(w, tr("Error"), tr("Error occured while reading line %1. \"name\" should be the same for lines where \"pid\" values are the same.").arg(lineno));
+					return false;
+				}
+				if (currentValue != value) {
+					QMessageBox::critical(w, tr("Error"), tr("Error occured while reading line %1. \"value\" should be the same for lines where \"pid\" values are the same.").arg(lineno));
+					return false;
+				}
+				polygon.push_back(QPointF(x, y));
+			}
+		}
+
+		++ lineno;
+	}
+}

--- a/libs/geodata/polygongroup/geodatapolygongroupcsvimporter.h
+++ b/libs/geodata/polygongroup/geodatapolygongroupcsvimporter.h
@@ -1,0 +1,17 @@
+#ifndef GEODATAPOLYGONGROUPCSVIMPORTER_H
+#define GEODATAPOLYGONGROUPCSVIMPORTER_H
+
+#include <guicore/pre/geodata/geodataimporter.h>
+
+class GeoDataPolygonGroupCsvImporter : public GeoDataImporter
+{
+public:
+	GeoDataPolygonGroupCsvImporter(GeoDataCreator* creator);
+
+	const QStringList fileDialogFilters() override;
+	const QStringList acceptableExtensions() override;
+
+	bool importData(GeoData* data, int index, QWidget* w) override;
+};
+
+#endif // GEODATAPOLYGONGROUPCSVIMPORTER_H

--- a/libs/geodata/polygongroup/geodatapolygongrouppolygon.cpp
+++ b/libs/geodata/polygongroup/geodatapolygongrouppolygon.cpp
@@ -248,6 +248,8 @@ void GeoDataPolygonGroupPolygon::applyOffset(double x, double y)
 
 	auto f = geos::geom::GeometryFactory::getDefaultInstance();
 	impl->m_polygon.reset(f->createPolygon(elr, holes));
+
+	setupBoundingRect();
 }
 
 void GeoDataPolygonGroupPolygon::setupBoundingRect()

--- a/libs/geodata/polygongroup/geodatapolygongrouppolygon.cpp
+++ b/libs/geodata/polygongroup/geodatapolygongrouppolygon.cpp
@@ -52,7 +52,7 @@ geos::geom::LinearRing* applyOffset(const geos::geom::LineString* string, double
 {
 	auto pol = buildPolygon(string);
 	for (auto& p : pol) {
-		p += QPointF(x, y);
+		p -= QPointF(x, y);
 	}
 	return buildRing(pol);
 }

--- a/libs/geodata/polygongroup/languages/iricGdPolygonGroup_ar_EG.ts
+++ b/libs/geodata/polygongroup/languages/iricGdPolygonGroup_ar_EG.ts
@@ -36,6 +36,116 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolygonGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Some polygon in this polygon group has holes, but holes are not exported to CSV file. If you want to export holes, please export to ESRI Shapefile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolygonGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polygons)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polygons) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Polygon should have three points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;pid&quot; value in line %1. &quot;pid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolygonGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/libs/geodata/polygongroup/languages/iricGdPolygonGroup_bg_BG.ts
+++ b/libs/geodata/polygongroup/languages/iricGdPolygonGroup_bg_BG.ts
@@ -36,6 +36,116 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolygonGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Some polygon in this polygon group has holes, but holes are not exported to CSV file. If you want to export holes, please export to ESRI Shapefile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolygonGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polygons)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polygons) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Polygon should have three points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;pid&quot; value in line %1. &quot;pid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolygonGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/libs/geodata/polygongroup/languages/iricGdPolygonGroup_bs_BA.ts
+++ b/libs/geodata/polygongroup/languages/iricGdPolygonGroup_bs_BA.ts
@@ -36,6 +36,116 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolygonGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Some polygon in this polygon group has holes, but holes are not exported to CSV file. If you want to export holes, please export to ESRI Shapefile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolygonGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polygons)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polygons) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Polygon should have three points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;pid&quot; value in line %1. &quot;pid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolygonGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/libs/geodata/polygongroup/languages/iricGdPolygonGroup_ca_ES.ts
+++ b/libs/geodata/polygongroup/languages/iricGdPolygonGroup_ca_ES.ts
@@ -36,6 +36,116 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolygonGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Some polygon in this polygon group has holes, but holes are not exported to CSV file. If you want to export holes, please export to ESRI Shapefile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolygonGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polygons)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polygons) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Polygon should have three points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;pid&quot; value in line %1. &quot;pid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolygonGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/libs/geodata/polygongroup/languages/iricGdPolygonGroup_cs_CZ.ts
+++ b/libs/geodata/polygongroup/languages/iricGdPolygonGroup_cs_CZ.ts
@@ -36,6 +36,116 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolygonGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Some polygon in this polygon group has holes, but holes are not exported to CSV file. If you want to export holes, please export to ESRI Shapefile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolygonGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polygons)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polygons) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Polygon should have three points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;pid&quot; value in line %1. &quot;pid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolygonGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/libs/geodata/polygongroup/languages/iricGdPolygonGroup_da_DK.ts
+++ b/libs/geodata/polygongroup/languages/iricGdPolygonGroup_da_DK.ts
@@ -36,6 +36,116 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolygonGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Some polygon in this polygon group has holes, but holes are not exported to CSV file. If you want to export holes, please export to ESRI Shapefile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolygonGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polygons)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polygons) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Polygon should have three points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;pid&quot; value in line %1. &quot;pid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolygonGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/libs/geodata/polygongroup/languages/iricGdPolygonGroup_de_DE.ts
+++ b/libs/geodata/polygongroup/languages/iricGdPolygonGroup_de_DE.ts
@@ -36,6 +36,116 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolygonGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Some polygon in this polygon group has holes, but holes are not exported to CSV file. If you want to export holes, please export to ESRI Shapefile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolygonGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polygons)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polygons) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Polygon should have three points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;pid&quot; value in line %1. &quot;pid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolygonGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/libs/geodata/polygongroup/languages/iricGdPolygonGroup_el_GR.ts
+++ b/libs/geodata/polygongroup/languages/iricGdPolygonGroup_el_GR.ts
@@ -36,6 +36,116 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolygonGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Some polygon in this polygon group has holes, but holes are not exported to CSV file. If you want to export holes, please export to ESRI Shapefile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolygonGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polygons)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polygons) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Polygon should have three points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;pid&quot; value in line %1. &quot;pid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolygonGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/libs/geodata/polygongroup/languages/iricGdPolygonGroup_es_ES.ts
+++ b/libs/geodata/polygongroup/languages/iricGdPolygonGroup_es_ES.ts
@@ -106,6 +106,116 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolygonGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation type="unfinished">Aviso</translation>
+    </message>
+    <message>
+        <source>Some polygon in this polygon group has holes, but holes are not exported to CSV file. If you want to export holes, please export to ESRI Shapefile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolygonGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polygons)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polygons) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Polygon should have three points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;pid&quot; value in line %1. &quot;pid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolygonGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/libs/geodata/polygongroup/languages/iricGdPolygonGroup_et_EE.ts
+++ b/libs/geodata/polygongroup/languages/iricGdPolygonGroup_et_EE.ts
@@ -36,6 +36,116 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolygonGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Some polygon in this polygon group has holes, but holes are not exported to CSV file. If you want to export holes, please export to ESRI Shapefile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolygonGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polygons)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polygons) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Polygon should have three points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;pid&quot; value in line %1. &quot;pid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolygonGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/libs/geodata/polygongroup/languages/iricGdPolygonGroup_eu_ES.ts
+++ b/libs/geodata/polygongroup/languages/iricGdPolygonGroup_eu_ES.ts
@@ -36,6 +36,116 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolygonGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Some polygon in this polygon group has holes, but holes are not exported to CSV file. If you want to export holes, please export to ESRI Shapefile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolygonGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polygons)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polygons) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Polygon should have three points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;pid&quot; value in line %1. &quot;pid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolygonGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/libs/geodata/polygongroup/languages/iricGdPolygonGroup_fi_FI.ts
+++ b/libs/geodata/polygongroup/languages/iricGdPolygonGroup_fi_FI.ts
@@ -36,6 +36,116 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolygonGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Some polygon in this polygon group has holes, but holes are not exported to CSV file. If you want to export holes, please export to ESRI Shapefile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolygonGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polygons)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polygons) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Polygon should have three points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;pid&quot; value in line %1. &quot;pid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolygonGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/libs/geodata/polygongroup/languages/iricGdPolygonGroup_fr_FR.ts
+++ b/libs/geodata/polygongroup/languages/iricGdPolygonGroup_fr_FR.ts
@@ -36,6 +36,116 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolygonGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Some polygon in this polygon group has holes, but holes are not exported to CSV file. If you want to export holes, please export to ESRI Shapefile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolygonGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polygons)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polygons) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Polygon should have three points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;pid&quot; value in line %1. &quot;pid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolygonGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/libs/geodata/polygongroup/languages/iricGdPolygonGroup_gl_ES.ts
+++ b/libs/geodata/polygongroup/languages/iricGdPolygonGroup_gl_ES.ts
@@ -36,6 +36,116 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolygonGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Some polygon in this polygon group has holes, but holes are not exported to CSV file. If you want to export holes, please export to ESRI Shapefile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolygonGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polygons)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polygons) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Polygon should have three points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;pid&quot; value in line %1. &quot;pid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolygonGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/libs/geodata/polygongroup/languages/iricGdPolygonGroup_hi_IN.ts
+++ b/libs/geodata/polygongroup/languages/iricGdPolygonGroup_hi_IN.ts
@@ -36,6 +36,116 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolygonGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Some polygon in this polygon group has holes, but holes are not exported to CSV file. If you want to export holes, please export to ESRI Shapefile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolygonGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polygons)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polygons) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Polygon should have three points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;pid&quot; value in line %1. &quot;pid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolygonGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/libs/geodata/polygongroup/languages/iricGdPolygonGroup_hu_HU.ts
+++ b/libs/geodata/polygongroup/languages/iricGdPolygonGroup_hu_HU.ts
@@ -36,6 +36,116 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolygonGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Some polygon in this polygon group has holes, but holes are not exported to CSV file. If you want to export holes, please export to ESRI Shapefile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolygonGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polygons)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polygons) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Polygon should have three points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;pid&quot; value in line %1. &quot;pid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolygonGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/libs/geodata/polygongroup/languages/iricGdPolygonGroup_id_ID.ts
+++ b/libs/geodata/polygongroup/languages/iricGdPolygonGroup_id_ID.ts
@@ -36,6 +36,116 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolygonGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Some polygon in this polygon group has holes, but holes are not exported to CSV file. If you want to export holes, please export to ESRI Shapefile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolygonGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polygons)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polygons) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Polygon should have three points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;pid&quot; value in line %1. &quot;pid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolygonGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/libs/geodata/polygongroup/languages/iricGdPolygonGroup_is_IS.ts
+++ b/libs/geodata/polygongroup/languages/iricGdPolygonGroup_is_IS.ts
@@ -36,6 +36,116 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolygonGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Some polygon in this polygon group has holes, but holes are not exported to CSV file. If you want to export holes, please export to ESRI Shapefile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolygonGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polygons)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polygons) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Polygon should have three points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;pid&quot; value in line %1. &quot;pid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolygonGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/libs/geodata/polygongroup/languages/iricGdPolygonGroup_it_IT.ts
+++ b/libs/geodata/polygongroup/languages/iricGdPolygonGroup_it_IT.ts
@@ -36,6 +36,116 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolygonGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Some polygon in this polygon group has holes, but holes are not exported to CSV file. If you want to export holes, please export to ESRI Shapefile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolygonGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polygons)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polygons) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Polygon should have three points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;pid&quot; value in line %1. &quot;pid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolygonGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/libs/geodata/polygongroup/languages/iricGdPolygonGroup_ja_JP.ts
+++ b/libs/geodata/polygongroup/languages/iricGdPolygonGroup_ja_JP.ts
@@ -205,6 +205,116 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolygonGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation>CSV ファイル</translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation>エラー</translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation>%1 へのエクスポートでエラーが発生しました。</translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation>警告</translation>
+    </message>
+    <message>
+        <source>Some polygon in this polygon group has holes, but holes are not exported to CSV file. If you want to export holes, please export to ESRI Shapefile.</source>
+        <translation>ポリゴンに、穴が空いているものがありますが、 CSVファイルには穴の情報をエクスポートできません。穴の情報をエクスポートしたい場合、ESRIシェープファイルにエクスポートしてください。</translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation>CSV ファイル (*.csv)</translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolygonGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polygons)</source>
+        <translation>CSV ファイル (ポリゴン)</translation>
+    </message>
+    <message>
+        <source>CSV file (Polygons) (*.csv)</source>
+        <translation>CSV ファイル (ポリゴン) (*.csv)</translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation>エラー</translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation>%1 を開けませんでした。</translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation>ヘッダ行の読み込み中にエラーが発生しました。UTF-8 エンコーディングで保存されているか確認してください。</translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation>ヘッダ行の読み込み中にエラーが発生しました。ヘッダには5列以上データがなくてはいけません。</translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation>ヘッダ行の読み込み中にエラーが発生しました。ヘッダには5列以上データがなくてはいけません。</translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation>ヘッダ行の読み込み中にエラーが発生しました。ヘッダには6列以上データがなくてはいけません。</translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation>%1行目の読み込み中にエラーが発生しました。データがありません。</translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Polygon should have three points at least.</source>
+        <translation>ヘッダ行の読み込み中にエラーが発生しました。%1 列目の値は &quot;%2&quot; のはずですが、&quot;%3&quot; が指定されています。</translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation>%1行目の読み込み中にエラーが発生しました。UTF-8 エンコーディングで保存されているか確認してください。</translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation>%1行目の読み込み中にエラーが発生しました。5列以上データがなくてはいけません。</translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation>%1行目の読み込み中にエラーが発生しました。6列以上データがなくてはいけません。</translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;pid&quot; value in line %1. &quot;pid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation>%1行目の &quot;pid&quot; の読み込み中にエラーが発生しました。 &quot;pid&quot; は整数値でなくてはいけませんが、 &quot;%2&quot; が指定されました。</translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation>%1行目の &quot;vid&quot; の読み込み中にエラーが発生しました。 &quot;vid&quot; は整数値でなくてはいけませんが、 &quot;%2&quot; が指定されました。</translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation>%1行目の &quot;x&quot; の読み込み中にエラーが発生しました。 &quot;x&quot; は実数値でなくてはいけませんが、 &quot;%2&quot; が指定されました。</translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation>%1行目の &quot;y&quot; の読み込み中にエラーが発生しました。 &quot;y&quot; は実数値でなくてはいけませんが、 &quot;%2&quot; が指定されました。</translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation>%1行目の &quot;value&quot; の読み込み中にエラーが発生しました。 &quot;value&quot; は実数値でなくてはいけませんが、 &quot;%2&quot; が指定されました。</translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation>%1行目の読み込み中にエラーが発生しました。 &quot;name&quot; は同じ &quot;pid&quot; の行で共通である必要があります。</translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation>%1行目の読み込み中にエラーが発生しました。 &quot;value&quot; は同じ &quot;pid&quot; の行で共通である必要があります。</translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolygonGroupMergeSettingDialog</name>
     <message>
         <source>Select data to merge</source>

--- a/libs/geodata/polygongroup/languages/iricGdPolygonGroup_ko_KR.ts
+++ b/libs/geodata/polygongroup/languages/iricGdPolygonGroup_ko_KR.ts
@@ -36,6 +36,116 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolygonGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Some polygon in this polygon group has holes, but holes are not exported to CSV file. If you want to export holes, please export to ESRI Shapefile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolygonGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polygons)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polygons) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Polygon should have three points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;pid&quot; value in line %1. &quot;pid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolygonGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/libs/geodata/polygongroup/languages/iricGdPolygonGroup_ky_KG.ts
+++ b/libs/geodata/polygongroup/languages/iricGdPolygonGroup_ky_KG.ts
@@ -36,6 +36,116 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolygonGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Some polygon in this polygon group has holes, but holes are not exported to CSV file. If you want to export holes, please export to ESRI Shapefile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolygonGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polygons)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polygons) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Polygon should have three points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;pid&quot; value in line %1. &quot;pid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolygonGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/libs/geodata/polygongroup/languages/iricGdPolygonGroup_lt_LT.ts
+++ b/libs/geodata/polygongroup/languages/iricGdPolygonGroup_lt_LT.ts
@@ -36,6 +36,116 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolygonGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Some polygon in this polygon group has holes, but holes are not exported to CSV file. If you want to export holes, please export to ESRI Shapefile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolygonGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polygons)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polygons) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Polygon should have three points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;pid&quot; value in line %1. &quot;pid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolygonGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/libs/geodata/polygongroup/languages/iricGdPolygonGroup_lv_LV.ts
+++ b/libs/geodata/polygongroup/languages/iricGdPolygonGroup_lv_LV.ts
@@ -36,6 +36,116 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolygonGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Some polygon in this polygon group has holes, but holes are not exported to CSV file. If you want to export holes, please export to ESRI Shapefile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolygonGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polygons)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polygons) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Polygon should have three points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;pid&quot; value in line %1. &quot;pid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolygonGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/libs/geodata/polygongroup/languages/iricGdPolygonGroup_nb_NO.ts
+++ b/libs/geodata/polygongroup/languages/iricGdPolygonGroup_nb_NO.ts
@@ -36,6 +36,116 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolygonGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Some polygon in this polygon group has holes, but holes are not exported to CSV file. If you want to export holes, please export to ESRI Shapefile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolygonGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polygons)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polygons) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Polygon should have three points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;pid&quot; value in line %1. &quot;pid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolygonGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/libs/geodata/polygongroup/languages/iricGdPolygonGroup_nl_NL.ts
+++ b/libs/geodata/polygongroup/languages/iricGdPolygonGroup_nl_NL.ts
@@ -36,6 +36,116 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolygonGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Some polygon in this polygon group has holes, but holes are not exported to CSV file. If you want to export holes, please export to ESRI Shapefile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolygonGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polygons)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polygons) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Polygon should have three points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;pid&quot; value in line %1. &quot;pid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolygonGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/libs/geodata/polygongroup/languages/iricGdPolygonGroup_pl_PL.ts
+++ b/libs/geodata/polygongroup/languages/iricGdPolygonGroup_pl_PL.ts
@@ -36,6 +36,116 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolygonGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Some polygon in this polygon group has holes, but holes are not exported to CSV file. If you want to export holes, please export to ESRI Shapefile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolygonGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polygons)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polygons) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Polygon should have three points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;pid&quot; value in line %1. &quot;pid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolygonGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/libs/geodata/polygongroup/languages/iricGdPolygonGroup_pt_BR.ts
+++ b/libs/geodata/polygongroup/languages/iricGdPolygonGroup_pt_BR.ts
@@ -99,6 +99,116 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolygonGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished">Erro</translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation type="unfinished">Atencao</translation>
+    </message>
+    <message>
+        <source>Some polygon in this polygon group has holes, but holes are not exported to CSV file. If you want to export holes, please export to ESRI Shapefile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolygonGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polygons)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polygons) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished">Erro</translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Polygon should have three points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;pid&quot; value in line %1. &quot;pid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolygonGroupMergeSettingDialog</name>
     <message>
         <source>Select data to merge</source>

--- a/libs/geodata/polygongroup/languages/iricGdPolygonGroup_pt_PT.ts
+++ b/libs/geodata/polygongroup/languages/iricGdPolygonGroup_pt_PT.ts
@@ -36,6 +36,116 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolygonGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Some polygon in this polygon group has holes, but holes are not exported to CSV file. If you want to export holes, please export to ESRI Shapefile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolygonGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polygons)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polygons) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Polygon should have three points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;pid&quot; value in line %1. &quot;pid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolygonGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/libs/geodata/polygongroup/languages/iricGdPolygonGroup_ro_RO.ts
+++ b/libs/geodata/polygongroup/languages/iricGdPolygonGroup_ro_RO.ts
@@ -36,6 +36,116 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolygonGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Some polygon in this polygon group has holes, but holes are not exported to CSV file. If you want to export holes, please export to ESRI Shapefile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolygonGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polygons)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polygons) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Polygon should have three points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;pid&quot; value in line %1. &quot;pid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolygonGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/libs/geodata/polygongroup/languages/iricGdPolygonGroup_ru_RU.ts
+++ b/libs/geodata/polygongroup/languages/iricGdPolygonGroup_ru_RU.ts
@@ -36,6 +36,116 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolygonGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Some polygon in this polygon group has holes, but holes are not exported to CSV file. If you want to export holes, please export to ESRI Shapefile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolygonGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polygons)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polygons) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Polygon should have three points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;pid&quot; value in line %1. &quot;pid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolygonGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/libs/geodata/polygongroup/languages/iricGdPolygonGroup_sl_SI.ts
+++ b/libs/geodata/polygongroup/languages/iricGdPolygonGroup_sl_SI.ts
@@ -36,6 +36,116 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolygonGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Some polygon in this polygon group has holes, but holes are not exported to CSV file. If you want to export holes, please export to ESRI Shapefile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolygonGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polygons)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polygons) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Polygon should have three points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;pid&quot; value in line %1. &quot;pid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolygonGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/libs/geodata/polygongroup/languages/iricGdPolygonGroup_sv_SE.ts
+++ b/libs/geodata/polygongroup/languages/iricGdPolygonGroup_sv_SE.ts
@@ -36,6 +36,116 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolygonGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Some polygon in this polygon group has holes, but holes are not exported to CSV file. If you want to export holes, please export to ESRI Shapefile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolygonGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polygons)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polygons) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Polygon should have three points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;pid&quot; value in line %1. &quot;pid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolygonGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/libs/geodata/polygongroup/languages/iricGdPolygonGroup_th_TH.ts
+++ b/libs/geodata/polygongroup/languages/iricGdPolygonGroup_th_TH.ts
@@ -36,6 +36,116 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolygonGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Some polygon in this polygon group has holes, but holes are not exported to CSV file. If you want to export holes, please export to ESRI Shapefile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolygonGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polygons)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polygons) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Polygon should have three points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;pid&quot; value in line %1. &quot;pid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolygonGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/libs/geodata/polygongroup/languages/iricGdPolygonGroup_tr_TR.ts
+++ b/libs/geodata/polygongroup/languages/iricGdPolygonGroup_tr_TR.ts
@@ -36,6 +36,116 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolygonGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Some polygon in this polygon group has holes, but holes are not exported to CSV file. If you want to export holes, please export to ESRI Shapefile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolygonGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polygons)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polygons) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Polygon should have three points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;pid&quot; value in line %1. &quot;pid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolygonGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/libs/geodata/polygongroup/languages/iricGdPolygonGroup_uk_UA.ts
+++ b/libs/geodata/polygongroup/languages/iricGdPolygonGroup_uk_UA.ts
@@ -36,6 +36,116 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolygonGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Some polygon in this polygon group has holes, but holes are not exported to CSV file. If you want to export holes, please export to ESRI Shapefile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolygonGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polygons)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polygons) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Polygon should have three points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;pid&quot; value in line %1. &quot;pid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolygonGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/libs/geodata/polygongroup/languages/iricGdPolygonGroup_vi_VN.ts
+++ b/libs/geodata/polygongroup/languages/iricGdPolygonGroup_vi_VN.ts
@@ -36,6 +36,116 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolygonGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Some polygon in this polygon group has holes, but holes are not exported to CSV file. If you want to export holes, please export to ESRI Shapefile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolygonGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polygons)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polygons) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Polygon should have three points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;pid&quot; value in line %1. &quot;pid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolygonGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/libs/geodata/polygongroup/languages/iricGdPolygonGroup_zh_CN.ts
+++ b/libs/geodata/polygongroup/languages/iricGdPolygonGroup_zh_CN.ts
@@ -114,6 +114,116 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolygonGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished">错误</translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation type="unfinished">警告</translation>
+    </message>
+    <message>
+        <source>Some polygon in this polygon group has holes, but holes are not exported to CSV file. If you want to export holes, please export to ESRI Shapefile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolygonGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polygons)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polygons) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished">错误</translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Polygon should have three points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;pid&quot; value in line %1. &quot;pid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolygonGroupMergeSettingDialog</name>
     <message>
         <source>Select data to merge</source>

--- a/libs/geodata/polygongroup/languages/iricGdPolygonGroup_zh_TW.ts
+++ b/libs/geodata/polygongroup/languages/iricGdPolygonGroup_zh_TW.ts
@@ -36,6 +36,116 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolygonGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Some polygon in this polygon group has holes, but holes are not exported to CSV file. If you want to export holes, please export to ESRI Shapefile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolygonGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polygons)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polygons) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Polygon should have three points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;pid&quot; value in line %1. &quot;pid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;pid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolygonGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/libs/geodata/polygongroup/polygongroup.pro
+++ b/libs/geodata/polygongroup/polygongroup.pro
@@ -159,6 +159,7 @@ HEADERS += gd_polygongroup_global.h \
            geodatapolygongroupcreator.h \
            geodatapolygongroupcreatort.h \
            geodatapolygongroupcsvexporter.h \
+           geodatapolygongroupcsvimporter.h \
            geodatapolygongroupintegercreator.h \
            geodatapolygongroupnodemappert.h \
            geodatapolygongrouppolygon.h \
@@ -178,6 +179,7 @@ FORMS +=
 SOURCES += geodatapolygongroup.cpp \
            geodatapolygongroupcreator.cpp \
            geodatapolygongroupcsvexporter.cpp \
+           geodatapolygongroupcsvimporter.cpp \
            geodatapolygongroupintegercreator.cpp \
            geodatapolygongrouppolygon.cpp \
            geodatapolygongrouprangecontainer.cpp \

--- a/libs/geodata/polygongroup/polygongroup.pro
+++ b/libs/geodata/polygongroup/polygongroup.pro
@@ -158,6 +158,7 @@ HEADERS += gd_polygongroup_global.h \
            geodatapolygongroupcellmappert.h \
            geodatapolygongroupcreator.h \
            geodatapolygongroupcreatort.h \
+           geodatapolygongroupcsvexporter.h \
            geodatapolygongroupintegercreator.h \
            geodatapolygongroupnodemappert.h \
            geodatapolygongrouppolygon.h \
@@ -176,6 +177,7 @@ HEADERS += gd_polygongroup_global.h \
 FORMS +=
 SOURCES += geodatapolygongroup.cpp \
            geodatapolygongroupcreator.cpp \
+           geodatapolygongroupcsvexporter.cpp \
            geodatapolygongroupintegercreator.cpp \
            geodatapolygongrouppolygon.cpp \
            geodatapolygongrouprangecontainer.cpp \

--- a/libs/geodata/polyline/geodatapolyline.cpp
+++ b/libs/geodata/polyline/geodatapolyline.cpp
@@ -683,7 +683,7 @@ void GeoDataPolyLine::copyShape(GeoDataPolyLine* polyline)
 
 void GeoDataPolyLine::doApplyOffset(double x, double y)
 {
-	std::vector<QPointF> pol = impl->m_polyLine->polyLine(QPointF(x, y));
+	std::vector<QPointF> pol = impl->m_polyLine->polyLine(QPointF(-x, -y));
 	impl->m_polyLine->setPolyLine(pol);
 }
 

--- a/libs/geodata/polyline/private/geodatapolyline_coordinateseditor.cpp
+++ b/libs/geodata/polyline/private/geodatapolyline_coordinateseditor.cpp
@@ -22,8 +22,9 @@ void GeoDataPolyLine::CoordinatesEditor::edit(GeoDataPolyLine* polyline)
 	applied = false;
 
 	auto coords = polyline->polyLine()->polyLine();
+	auto coords2 = applyOffset(coords);
 
-	CoordinatesEdit::edit(coords, polyline->preProcessorWindow(),
+	CoordinatesEdit::edit(coords2, polyline->preProcessorWindow(),
 												acceptCallback,
 												rejectCallback,
 												applyCallback,

--- a/libs/geodata/polylinegroup/geodatapolylinegroup.h
+++ b/libs/geodata/polylinegroup/geodatapolylinegroup.h
@@ -44,6 +44,7 @@ private:
 
 public:
 	friend class GeoDataPolyLineGroupAttributeBrowser;
+	friend class GeoDataPolyLineGroupCsvImporter;
 	friend class GeoDataPolyLineGroupShpImporter;
 };
 

--- a/libs/geodata/polylinegroup/geodatapolylinegroupcreator.cpp
+++ b/libs/geodata/polylinegroup/geodatapolylinegroupcreator.cpp
@@ -1,8 +1,9 @@
 #include "geodatapolylinegroup.h"
 #include "geodatapolylinegroupcreator.h"
 #include "geodatapolylinegroupcsvexporter.h"
-#include "geodatapolylinegroupshpimporter.h"
+#include "geodatapolylinegroupcsvimporter.h"
 #include "geodatapolylinegroupshpexporter.h"
+#include "geodatapolylinegroupshpimporter.h"
 
 #include <guicore/pre/base/preprocessorgeodatadataiteminterface.h>
 
@@ -12,6 +13,7 @@ GeoDataPolyLineGroupCreator::GeoDataPolyLineGroupCreator(const QString& typeName
 	GeoDataPolyDataGroupCreator {typeName, tr("Polyline Group")}
 {
 	importers().push_back(new GeoDataPolyLineGroupShpImporter(this));
+	importers().push_back(new GeoDataPolyLineGroupCsvImporter(this));
 	exporters().push_back(new GeoDataPolyLineGroupShpExporter(this));
 	exporters().push_back(new GeoDataPolyLineGroupCsvExporter(this));
 }

--- a/libs/geodata/polylinegroup/geodatapolylinegroupcreator.cpp
+++ b/libs/geodata/polylinegroup/geodatapolylinegroupcreator.cpp
@@ -1,5 +1,6 @@
 #include "geodatapolylinegroup.h"
 #include "geodatapolylinegroupcreator.h"
+#include "geodatapolylinegroupcsvexporter.h"
 #include "geodatapolylinegroupshpimporter.h"
 #include "geodatapolylinegroupshpexporter.h"
 
@@ -12,6 +13,7 @@ GeoDataPolyLineGroupCreator::GeoDataPolyLineGroupCreator(const QString& typeName
 {
 	importers().push_back(new GeoDataPolyLineGroupShpImporter(this));
 	exporters().push_back(new GeoDataPolyLineGroupShpExporter(this));
+	exporters().push_back(new GeoDataPolyLineGroupCsvExporter(this));
 }
 
 QString GeoDataPolyLineGroupCreator::name(unsigned int index) const

--- a/libs/geodata/polylinegroup/geodatapolylinegroupcsvexporter.cpp
+++ b/libs/geodata/polylinegroup/geodatapolylinegroupcsvexporter.cpp
@@ -1,0 +1,68 @@
+#include "geodatapolylinegroup.h"
+#include "geodatapolylinegrouppolyline.h"
+#include "geodatapolylinegroupcsvexporter.h"
+
+#include <guicore/project/projectdata.h>
+#include <guicore/project/projectmainfile.h>
+
+#include <QDir>
+#include <QFile>
+#include <QMessageBox>
+#include <QTextStream>
+
+GeoDataPolyLineGroupCsvExporter::GeoDataPolyLineGroupCsvExporter(GeoDataCreator* creator) :
+	GeoDataExporter {tr("CSV file"), creator}
+{}
+
+bool GeoDataPolyLineGroupCsvExporter::doExport(GeoData* data, const QString& filename, const QString& /*selectedFilter*/, QWidget* w, ProjectData* pd)
+{
+	auto group = dynamic_cast<GeoDataPolyLineGroup*>(data);
+	group->mergeEditTargetData();
+
+	QFile file(filename);
+	if (! file.open(QIODevice::WriteOnly | QIODevice::Text)) {
+		QMessageBox::critical(w, tr("Error"), tr("Error occured while exporting to %1.").arg(QDir::toNativeSeparators(filename)));
+		return false;
+	}
+	QTextStream stream(&file);
+	stream.setRealNumberNotation(QTextStream::FixedNotation);
+	stream.setRealNumberPrecision(3);
+	stream.setCodec("UTF-8");
+	// write header
+	bool isRef = data->gridAttribute()->isReferenceInformation();
+	if (isRef) {
+		stream << "lid,vid,x,y,name" << endl;
+	} else {
+		stream << "lid,vid,x,y,name,value" << endl;
+	}
+
+	auto o = pd->mainfile()->offset();
+	// write data
+	int lid = 1;
+	for (auto d : group->allData()) {
+		auto l = dynamic_cast<GeoDataPolyLineGroupPolyLine*> (d);
+		auto points = l->points();
+		int vid = 1;
+		for (auto point : points) {
+			if (isRef) {
+				stream << lid << "," << vid << "," << point.x() + o.x() << "," << point.y() + o.y() << "," << l->name() << endl;
+			} else {
+				stream << lid << "," << vid << "," << point.x() + o.x() << "," << point.y() + o.y() << "," << l->name() << "," << l->value().toDouble() << endl;
+			}
+			++ vid;
+		}
+		++ lid;
+	}
+	file.close();
+
+	return true;
+}
+
+const QStringList GeoDataPolyLineGroupCsvExporter::fileDialogFilters()
+{
+	QStringList ret;
+
+	ret << tr("CSV file (*.csv)");
+
+	return ret;
+}

--- a/libs/geodata/polylinegroup/geodatapolylinegroupcsvexporter.h
+++ b/libs/geodata/polylinegroup/geodatapolylinegroupcsvexporter.h
@@ -1,0 +1,15 @@
+#ifndef GEODATAPOLYLINEGROUPCSVEXPORTER_H
+#define GEODATAPOLYLINEGROUPCSVEXPORTER_H
+
+#include <guicore/pre/geodata/geodataexporter.h>
+
+class GeoDataPolyLineGroupCsvExporter : public GeoDataExporter
+{
+public:
+	GeoDataPolyLineGroupCsvExporter(GeoDataCreator* creator);
+
+	bool doExport(GeoData* data, const QString& filename, const QString& selectedFilter, QWidget* w, ProjectData* pd) override;
+	const QStringList fileDialogFilters() override;
+};
+
+#endif // GEODATAPOLYLINEGROUPCSVEXPORTER_H

--- a/libs/geodata/polylinegroup/geodatapolylinegroupcsvimporter.cpp
+++ b/libs/geodata/polylinegroup/geodatapolylinegroupcsvimporter.cpp
@@ -1,0 +1,194 @@
+#include "geodatapolylinegroup.h"
+#include "geodatapolylinegroupcsvimporter.h"
+#include "geodatapolylinegrouppolyline.h"
+
+#include <QDir>
+#include <QFile>
+#include <QMessageBox>
+#include <QTextStream>
+
+namespace {
+
+void addNewLine(GeoDataPolyLineGroup* group, const QString& name, double value, const std::vector<QPointF>& points)
+{
+	auto newLine = new GeoDataPolyLineGroupPolyLine(points, group);
+	newLine->setName(name);
+	newLine->setValue(value);
+	group->addData(newLine);
+}
+
+} // namespace
+
+GeoDataPolyLineGroupCsvImporter::GeoDataPolyLineGroupCsvImporter(GeoDataCreator* creator) :
+	GeoDataImporter {"csv_polyline_group", tr("CSV file (Polylines)"), creator}
+{}
+
+const QStringList GeoDataPolyLineGroupCsvImporter::fileDialogFilters()
+{
+	QStringList ret;
+	ret.append(tr("CSV file (Polylines) (*.csv)"));
+	return ret;
+}
+
+const QStringList GeoDataPolyLineGroupCsvImporter::acceptableExtensions()
+{
+	QStringList ret;
+	ret.append("csv");
+	return ret;
+}
+
+bool GeoDataPolyLineGroupCsvImporter::importData(GeoData* data, int index, QWidget* w)
+{
+	auto group = dynamic_cast<GeoDataPolyLineGroup*>(data);
+
+	QFile file(filename());
+	if (! file.open(QIODevice::ReadOnly | QIODevice::Text)) {
+		QMessageBox::critical(w, tr("Error"), tr("Error occured while opening %1").arg(QDir::toNativeSeparators(filename())));
+		return false;
+	}
+	QTextStream stream(&file);
+	stream.setCodec("UTF-8");
+	bool isRef = data->gridAttribute()->isReferenceInformation();
+
+	// check header
+	QString buffer;
+	bool ok = stream.readLineInto(&buffer);
+	if (! ok) {
+		QMessageBox::critical(w, tr("Error"), tr("Error occured while reading header line. Make sure the file is saved in UTF-8 encoding."));
+		return false;
+	}
+	auto frags = buffer.split(",");
+	QStringList headers;
+	headers << "lid" << "vid" << "x" << "y" << "name";
+	if (isRef) {
+		if (frags.size() < 5) {
+			QMessageBox::critical(w, tr("Error"), tr("Error occured while reading header line. Header should have 5 columns at least."));
+			return false;
+		}
+	} else {
+		if (frags.size() < 6) {
+			QMessageBox::critical(w, tr("Error"), tr("Error occured while reading header line. Header should have 6 columns at least."));
+			return false;
+		}
+		headers << "value";
+	}
+	for (int i = 0; i < headers.size(); ++i) {
+		QString f = frags.at(i).trimmed();
+		if (f != headers.at(i)) {
+			QMessageBox::critical(w, tr("Error"), tr("Error occured while reading header line. Column %1 should be \"%2\", but \"%3\" is given.").arg(i + 1).arg(headers.at(i)).arg(f));
+			return false;
+		}
+	}
+	int lineno = 2;
+
+	int currentLid = 0;
+	QString currentName;
+	double currentValue = 0;
+	std::vector<QPointF> points;
+
+	while (true) {
+		bool ok = stream.readLineInto(&buffer);
+		if (! ok) {
+			if (stream.atEnd()) {
+				if (points.size() == 0) {
+					QMessageBox::critical(w, tr("Error"), tr("Error occured while reading line %1. There is no data.").arg(lineno - 1));
+					return false;
+				}
+
+				if (points.size() == 1) {
+					QMessageBox::critical(w, tr("Error"), tr("Error occured while reading line %1. Line should have two points at least.").arg(lineno - 1));
+					return false;
+				}
+				addNewLine(group, currentName, currentValue, points);
+				// successfully read all data
+				group->setupDataItem();
+				group->updateAttributeBrowser(true);
+				group->updateVtkObjects();
+				group->updateIndex();
+				return true;
+			}
+			// error occured
+			QMessageBox::critical(w, tr("Error"), tr("Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.").arg(lineno));
+			return false;
+		}
+		auto frags = buffer.split(",");
+		if (isRef) {
+			if (frags.size() < 5) {
+				QMessageBox::critical(w, tr("Error"), tr("Error occured while reading line %1. Data should have 5 columns at least.").arg(lineno));
+				return false;
+			}
+		} else {
+			if (frags.size() < 6) {
+				QMessageBox::critical(w, tr("Error"), tr("Error occured while reading line %1. Data should have 6 columns at least.").arg(lineno));
+				return false;
+			}
+			headers << "value";
+		}
+		int lid, vid;
+		double x, y, value = 0;
+		QString name;
+
+		lid = frags.at(0).toInt(&ok);
+		if (! ok) {
+			QMessageBox::critical(w, tr("Error"), tr("Error occured while reading \"lid\" value in line %1. \"lid\" should be integer value but \"%2\" is specified.").arg(lineno).arg(frags.at(0)));
+			return false;
+		}
+		vid = frags.at(1).toInt(&ok);
+		if (! ok) {
+			QMessageBox::critical(w, tr("Error"), tr("Error occured while reading \"vid\" value in line %1. \"vid\" should be integer value but \"%2\" is specified.").arg(lineno).arg(frags.at(1)));
+			return false;
+		}
+		x = frags.at(2).toDouble(&ok);
+		if (! ok) {
+			QMessageBox::critical(w, tr("Error"), tr("Error occured while reading \"x\" value in line %1. \"x\" should be real value but \"%2\" is specified.").arg(lineno).arg(frags.at(2)));
+			return false;
+		}
+		y = frags.at(3).toDouble(&ok);
+		if (! ok) {
+			QMessageBox::critical(w, tr("Error"), tr("Error occured while reading \"y\" value in line %1. \"y\" should be real value but \"%2\" is specified.").arg(lineno).arg(frags.at(3)));
+			return false;
+		}
+		name = frags.at(4);
+		if (! isRef) {
+			value = frags.at(5).toDouble(&ok);
+			if (! ok) {
+				QMessageBox::critical(w, tr("Error"), tr("Error occured while reading \"value\" value in line %1. \"value\" should be real value but \"%2\" is specified.").arg(lineno).arg(frags.at(5)));
+				return false;
+			}
+		}
+		if (points.size() == 0) {
+			// this is the first data
+			currentLid = lid;
+			currentName = name;
+			currentValue = value;
+			points.push_back(QPointF(x, y));
+		} else {
+			if (lid != currentLid) {
+				// old line finished
+				if (points.size() == 1) {
+					QMessageBox::critical(w, tr("Error"), tr("Error occured while reading line %1. Line should have two points at least.").arg(lineno - 1));
+					return false;
+				}
+				addNewLine(group, currentName, currentValue, points);
+
+				currentLid = lid;
+				currentName = name;
+				currentValue = value;
+				points.clear();
+				points.push_back(QPointF(x, y));
+			} else {
+				if (currentName != name) {
+					QMessageBox::critical(w, tr("Error"), tr("Error occured while reading line %1. \"name\" should be the same for lines where \"lid\" values are the same.").arg(lineno));
+					return false;
+				}
+				if (currentValue != value) {
+					QMessageBox::critical(w, tr("Error"), tr("Error occured while reading line %1. \"value\" should be the same for lines where \"lid\" values are the same.").arg(lineno));
+					return false;
+				}
+				points.push_back(QPointF(x, y));
+			}
+		}
+
+		++ lineno;
+	}
+}

--- a/libs/geodata/polylinegroup/geodatapolylinegroupcsvimporter.h
+++ b/libs/geodata/polylinegroup/geodatapolylinegroupcsvimporter.h
@@ -1,0 +1,17 @@
+#ifndef GEODATAPOLYLINEGROUPCSVIMPORTER_H
+#define GEODATAPOLYLINEGROUPCSVIMPORTER_H
+
+#include <guicore/pre/geodata/geodataimporter.h>
+
+class GeoDataPolyLineGroupCsvImporter : public GeoDataImporter
+{
+public:
+	GeoDataPolyLineGroupCsvImporter(GeoDataCreator* creator);
+
+	const QStringList fileDialogFilters() override;
+	const QStringList acceptableExtensions() override;
+
+	bool importData(GeoData* data, int index, QWidget* w) override;
+};
+
+#endif // GEODATAPOLYLINEGROUPCSVIMPORTER_H

--- a/libs/geodata/polylinegroup/geodatapolylinegrouppolyline.cpp
+++ b/libs/geodata/polylinegroup/geodatapolylinegrouppolyline.cpp
@@ -140,6 +140,7 @@ void GeoDataPolyLineGroupPolyLine::copyShapeTo(GeoDataPolyData* data)
 	auto l = dynamic_cast<GeoDataPolyLine*> (data);
 	l->setShape(getGeosLineString());
 	l->setMouseEventMode(GeoDataPolyLine::meNormal);
+	l->updateActionStatus();
 }
 
 void GeoDataPolyLineGroupPolyLine::loadExternalData(QDataStream* stream)

--- a/libs/geodata/polylinegroup/geodatapolylinegrouppolyline.cpp
+++ b/libs/geodata/polylinegroup/geodatapolylinegrouppolyline.cpp
@@ -177,6 +177,7 @@ void GeoDataPolyLineGroupPolyLine::applyOffset(double x, double y)
 	auto ls = impl->m_polyLine.get();
 
 	impl->m_polyLine.reset(::applyOffset(ls, x, y));
+	setupBoundingRect();
 }
 
 void GeoDataPolyLineGroupPolyLine::applyShape()

--- a/libs/geodata/polylinegroup/geodatapolylinegrouppolyline.cpp
+++ b/libs/geodata/polylinegroup/geodatapolylinegrouppolyline.cpp
@@ -59,7 +59,7 @@ geos::geom::LineString* applyOffset(const geos::geom::LineString* string, double
 {
 	auto pol = buildPolyLine(string);
 	for (auto& p : pol) {
-		p += QPointF(x, y);
+		p -= QPointF(x, y);
 	}
 	return buildString(pol);
 }

--- a/libs/geodata/polylinegroup/languages/iricGdPolyLineGroup_ar_EG.ts
+++ b/libs/geodata/polylinegroup/languages/iricGdPolyLineGroup_ar_EG.ts
@@ -40,6 +40,108 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolyLineGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polylines)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polylines) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Line should have two points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;lid&quot; value in line %1. &quot;lid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolyLineGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/libs/geodata/polylinegroup/languages/iricGdPolyLineGroup_bg_BG.ts
+++ b/libs/geodata/polylinegroup/languages/iricGdPolyLineGroup_bg_BG.ts
@@ -40,6 +40,108 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolyLineGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polylines)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polylines) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Line should have two points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;lid&quot; value in line %1. &quot;lid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolyLineGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/libs/geodata/polylinegroup/languages/iricGdPolyLineGroup_bs_BA.ts
+++ b/libs/geodata/polylinegroup/languages/iricGdPolyLineGroup_bs_BA.ts
@@ -40,6 +40,108 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolyLineGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polylines)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polylines) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Line should have two points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;lid&quot; value in line %1. &quot;lid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolyLineGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/libs/geodata/polylinegroup/languages/iricGdPolyLineGroup_ca_ES.ts
+++ b/libs/geodata/polylinegroup/languages/iricGdPolyLineGroup_ca_ES.ts
@@ -40,6 +40,108 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolyLineGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polylines)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polylines) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Line should have two points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;lid&quot; value in line %1. &quot;lid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolyLineGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/libs/geodata/polylinegroup/languages/iricGdPolyLineGroup_cs_CZ.ts
+++ b/libs/geodata/polylinegroup/languages/iricGdPolyLineGroup_cs_CZ.ts
@@ -40,6 +40,108 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolyLineGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polylines)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polylines) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Line should have two points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;lid&quot; value in line %1. &quot;lid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolyLineGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/libs/geodata/polylinegroup/languages/iricGdPolyLineGroup_da_DK.ts
+++ b/libs/geodata/polylinegroup/languages/iricGdPolyLineGroup_da_DK.ts
@@ -40,6 +40,108 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolyLineGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polylines)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polylines) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Line should have two points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;lid&quot; value in line %1. &quot;lid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolyLineGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/libs/geodata/polylinegroup/languages/iricGdPolyLineGroup_de_DE.ts
+++ b/libs/geodata/polylinegroup/languages/iricGdPolyLineGroup_de_DE.ts
@@ -40,6 +40,108 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolyLineGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polylines)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polylines) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Line should have two points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;lid&quot; value in line %1. &quot;lid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolyLineGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/libs/geodata/polylinegroup/languages/iricGdPolyLineGroup_el_GR.ts
+++ b/libs/geodata/polylinegroup/languages/iricGdPolyLineGroup_el_GR.ts
@@ -40,6 +40,108 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolyLineGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polylines)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polylines) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Line should have two points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;lid&quot; value in line %1. &quot;lid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolyLineGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/libs/geodata/polylinegroup/languages/iricGdPolyLineGroup_es_ES.ts
+++ b/libs/geodata/polylinegroup/languages/iricGdPolyLineGroup_es_ES.ts
@@ -40,6 +40,108 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolyLineGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polylines)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polylines) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Line should have two points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;lid&quot; value in line %1. &quot;lid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolyLineGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/libs/geodata/polylinegroup/languages/iricGdPolyLineGroup_et_EE.ts
+++ b/libs/geodata/polylinegroup/languages/iricGdPolyLineGroup_et_EE.ts
@@ -40,6 +40,108 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolyLineGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polylines)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polylines) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Line should have two points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;lid&quot; value in line %1. &quot;lid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolyLineGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/libs/geodata/polylinegroup/languages/iricGdPolyLineGroup_eu_ES.ts
+++ b/libs/geodata/polylinegroup/languages/iricGdPolyLineGroup_eu_ES.ts
@@ -40,6 +40,108 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolyLineGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polylines)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polylines) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Line should have two points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;lid&quot; value in line %1. &quot;lid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolyLineGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/libs/geodata/polylinegroup/languages/iricGdPolyLineGroup_fi_FI.ts
+++ b/libs/geodata/polylinegroup/languages/iricGdPolyLineGroup_fi_FI.ts
@@ -40,6 +40,108 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolyLineGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polylines)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polylines) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Line should have two points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;lid&quot; value in line %1. &quot;lid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolyLineGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/libs/geodata/polylinegroup/languages/iricGdPolyLineGroup_fr_FR.ts
+++ b/libs/geodata/polylinegroup/languages/iricGdPolyLineGroup_fr_FR.ts
@@ -40,6 +40,108 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolyLineGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polylines)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polylines) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Line should have two points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;lid&quot; value in line %1. &quot;lid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolyLineGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/libs/geodata/polylinegroup/languages/iricGdPolyLineGroup_gl_ES.ts
+++ b/libs/geodata/polylinegroup/languages/iricGdPolyLineGroup_gl_ES.ts
@@ -40,6 +40,108 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolyLineGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polylines)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polylines) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Line should have two points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;lid&quot; value in line %1. &quot;lid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolyLineGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/libs/geodata/polylinegroup/languages/iricGdPolyLineGroup_hi_IN.ts
+++ b/libs/geodata/polylinegroup/languages/iricGdPolyLineGroup_hi_IN.ts
@@ -40,6 +40,108 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolyLineGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polylines)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polylines) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Line should have two points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;lid&quot; value in line %1. &quot;lid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolyLineGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/libs/geodata/polylinegroup/languages/iricGdPolyLineGroup_hu_HU.ts
+++ b/libs/geodata/polylinegroup/languages/iricGdPolyLineGroup_hu_HU.ts
@@ -40,6 +40,108 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolyLineGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polylines)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polylines) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Line should have two points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;lid&quot; value in line %1. &quot;lid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolyLineGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/libs/geodata/polylinegroup/languages/iricGdPolyLineGroup_id_ID.ts
+++ b/libs/geodata/polylinegroup/languages/iricGdPolyLineGroup_id_ID.ts
@@ -40,6 +40,108 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolyLineGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polylines)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polylines) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Line should have two points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;lid&quot; value in line %1. &quot;lid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolyLineGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/libs/geodata/polylinegroup/languages/iricGdPolyLineGroup_is_IS.ts
+++ b/libs/geodata/polylinegroup/languages/iricGdPolyLineGroup_is_IS.ts
@@ -40,6 +40,108 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolyLineGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polylines)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polylines) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Line should have two points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;lid&quot; value in line %1. &quot;lid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolyLineGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/libs/geodata/polylinegroup/languages/iricGdPolyLineGroup_it_IT.ts
+++ b/libs/geodata/polylinegroup/languages/iricGdPolyLineGroup_it_IT.ts
@@ -40,6 +40,108 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolyLineGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polylines)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polylines) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Line should have two points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;lid&quot; value in line %1. &quot;lid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolyLineGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/libs/geodata/polylinegroup/languages/iricGdPolyLineGroup_ja_JP.ts
+++ b/libs/geodata/polylinegroup/languages/iricGdPolyLineGroup_ja_JP.ts
@@ -217,6 +217,108 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolyLineGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation>CSV ファイル</translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation>エラー</translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation>%1 へのエクスポートでエラーが発生しました。</translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation>CSV ファイル (*.csv)</translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polylines)</source>
+        <translation>CSV ファイル (線)</translation>
+    </message>
+    <message>
+        <source>CSV file (Polylines) (*.csv)</source>
+        <translation>CSV ファイル (線) (*.csv)</translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation>エラー</translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation>%1 を開けませんでした。</translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation>ヘッダ行の読み込み中にエラーが発生しました。UTF-8 エンコーディングで保存されているか確認してください。</translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation>ヘッダ行の読み込み中にエラーが発生しました。ヘッダには5列以上データがなくてはいけません。</translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation>ヘッダ行の読み込み中にエラーが発生しました。ヘッダには6列以上データがなくてはいけません。</translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation>ヘッダ行の読み込み中にエラーが発生しました。%1 列目の値は &quot;%2&quot; のはずですが、&quot;%3&quot; が指定されています。</translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation>%1行目の読み込み中にエラーが発生しました。データがありません。</translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Line should have two points at least.</source>
+        <translation>%1行目の読み込み中にエラーが発生しました。線には最低限点が2つなくてはいけません。</translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation>%1行目の読み込み中にエラーが発生しました。UTF-8 エンコーディングで保存されているか確認してください。</translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation>%1行目の読み込み中にエラーが発生しました。5列以上データがなくてはいけません。</translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation>%1行目の読み込み中にエラーが発生しました。6列以上データがなくてはいけません。</translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;lid&quot; value in line %1. &quot;lid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation>%1行目の &quot;lid&quot; の読み込み中にエラーが発生しました。 &quot;lid&quot; は整数値でなくてはいけませんが、 &quot;%2&quot; が指定されました。</translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation>%1行目の &quot;vid&quot; の読み込み中にエラーが発生しました。 &quot;vid&quot; は整数値でなくてはいけませんが、 &quot;%2&quot; が指定されました。</translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation>%1行目の &quot;x&quot; の読み込み中にエラーが発生しました。 &quot;x&quot; は実数値でなくてはいけませんが、 &quot;%2&quot; が指定されました。</translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation>%1行目の &quot;y&quot; の読み込み中にエラーが発生しました。 &quot;y&quot; は実数値でなくてはいけませんが、 &quot;%2&quot; が指定されました。</translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation>%1行目の &quot;value&quot; の読み込み中にエラーが発生しました。 &quot;value&quot; は実数値でなくてはいけませんが、 &quot;%2&quot; が指定されました。</translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation>%1行目の読み込み中にエラーが発生しました。 &quot;name&quot; は同じ &quot;lid&quot; の行で共通である必要があります。</translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation>%1行目の読み込み中にエラーが発生しました。 &quot;value&quot; は同じ &quot;lid&quot; の行で共通である必要があります。</translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolyLineGroupMergeSettingDialog</name>
     <message>
         <source>Select data to merge</source>

--- a/libs/geodata/polylinegroup/languages/iricGdPolyLineGroup_ko_KR.ts
+++ b/libs/geodata/polylinegroup/languages/iricGdPolyLineGroup_ko_KR.ts
@@ -40,6 +40,108 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolyLineGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polylines)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polylines) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Line should have two points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;lid&quot; value in line %1. &quot;lid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolyLineGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/libs/geodata/polylinegroup/languages/iricGdPolyLineGroup_ky_KG.ts
+++ b/libs/geodata/polylinegroup/languages/iricGdPolyLineGroup_ky_KG.ts
@@ -40,6 +40,108 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolyLineGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polylines)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polylines) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Line should have two points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;lid&quot; value in line %1. &quot;lid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolyLineGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/libs/geodata/polylinegroup/languages/iricGdPolyLineGroup_lt_LT.ts
+++ b/libs/geodata/polylinegroup/languages/iricGdPolyLineGroup_lt_LT.ts
@@ -40,6 +40,108 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolyLineGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polylines)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polylines) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Line should have two points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;lid&quot; value in line %1. &quot;lid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolyLineGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/libs/geodata/polylinegroup/languages/iricGdPolyLineGroup_lv_LV.ts
+++ b/libs/geodata/polylinegroup/languages/iricGdPolyLineGroup_lv_LV.ts
@@ -40,6 +40,108 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolyLineGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polylines)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polylines) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Line should have two points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;lid&quot; value in line %1. &quot;lid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolyLineGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/libs/geodata/polylinegroup/languages/iricGdPolyLineGroup_nb_NO.ts
+++ b/libs/geodata/polylinegroup/languages/iricGdPolyLineGroup_nb_NO.ts
@@ -40,6 +40,108 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolyLineGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polylines)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polylines) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Line should have two points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;lid&quot; value in line %1. &quot;lid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolyLineGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/libs/geodata/polylinegroup/languages/iricGdPolyLineGroup_nl_NL.ts
+++ b/libs/geodata/polylinegroup/languages/iricGdPolyLineGroup_nl_NL.ts
@@ -40,6 +40,108 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolyLineGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polylines)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polylines) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Line should have two points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;lid&quot; value in line %1. &quot;lid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolyLineGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/libs/geodata/polylinegroup/languages/iricGdPolyLineGroup_pl_PL.ts
+++ b/libs/geodata/polylinegroup/languages/iricGdPolyLineGroup_pl_PL.ts
@@ -40,6 +40,108 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolyLineGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polylines)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polylines) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Line should have two points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;lid&quot; value in line %1. &quot;lid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolyLineGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/libs/geodata/polylinegroup/languages/iricGdPolyLineGroup_pt_BR.ts
+++ b/libs/geodata/polylinegroup/languages/iricGdPolyLineGroup_pt_BR.ts
@@ -40,6 +40,108 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolyLineGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polylines)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polylines) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Line should have two points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;lid&quot; value in line %1. &quot;lid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolyLineGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/libs/geodata/polylinegroup/languages/iricGdPolyLineGroup_pt_PT.ts
+++ b/libs/geodata/polylinegroup/languages/iricGdPolyLineGroup_pt_PT.ts
@@ -40,6 +40,108 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolyLineGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polylines)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polylines) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Line should have two points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;lid&quot; value in line %1. &quot;lid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolyLineGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/libs/geodata/polylinegroup/languages/iricGdPolyLineGroup_ro_RO.ts
+++ b/libs/geodata/polylinegroup/languages/iricGdPolyLineGroup_ro_RO.ts
@@ -40,6 +40,108 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolyLineGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polylines)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polylines) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Line should have two points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;lid&quot; value in line %1. &quot;lid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolyLineGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/libs/geodata/polylinegroup/languages/iricGdPolyLineGroup_ru_RU.ts
+++ b/libs/geodata/polylinegroup/languages/iricGdPolyLineGroup_ru_RU.ts
@@ -40,6 +40,108 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolyLineGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polylines)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polylines) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Line should have two points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;lid&quot; value in line %1. &quot;lid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolyLineGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/libs/geodata/polylinegroup/languages/iricGdPolyLineGroup_sl_SI.ts
+++ b/libs/geodata/polylinegroup/languages/iricGdPolyLineGroup_sl_SI.ts
@@ -40,6 +40,108 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolyLineGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polylines)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polylines) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Line should have two points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;lid&quot; value in line %1. &quot;lid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolyLineGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/libs/geodata/polylinegroup/languages/iricGdPolyLineGroup_sv_SE.ts
+++ b/libs/geodata/polylinegroup/languages/iricGdPolyLineGroup_sv_SE.ts
@@ -40,6 +40,108 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolyLineGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polylines)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polylines) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Line should have two points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;lid&quot; value in line %1. &quot;lid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolyLineGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/libs/geodata/polylinegroup/languages/iricGdPolyLineGroup_th_TH.ts
+++ b/libs/geodata/polylinegroup/languages/iricGdPolyLineGroup_th_TH.ts
@@ -40,6 +40,108 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolyLineGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polylines)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polylines) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Line should have two points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;lid&quot; value in line %1. &quot;lid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolyLineGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/libs/geodata/polylinegroup/languages/iricGdPolyLineGroup_tr_TR.ts
+++ b/libs/geodata/polylinegroup/languages/iricGdPolyLineGroup_tr_TR.ts
@@ -40,6 +40,108 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolyLineGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polylines)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polylines) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Line should have two points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;lid&quot; value in line %1. &quot;lid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolyLineGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/libs/geodata/polylinegroup/languages/iricGdPolyLineGroup_uk_UA.ts
+++ b/libs/geodata/polylinegroup/languages/iricGdPolyLineGroup_uk_UA.ts
@@ -40,6 +40,108 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolyLineGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polylines)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polylines) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Line should have two points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;lid&quot; value in line %1. &quot;lid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolyLineGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/libs/geodata/polylinegroup/languages/iricGdPolyLineGroup_vi_VN.ts
+++ b/libs/geodata/polylinegroup/languages/iricGdPolyLineGroup_vi_VN.ts
@@ -40,6 +40,108 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolyLineGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polylines)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polylines) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Line should have two points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;lid&quot; value in line %1. &quot;lid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolyLineGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/libs/geodata/polylinegroup/languages/iricGdPolyLineGroup_zh_CN.ts
+++ b/libs/geodata/polylinegroup/languages/iricGdPolyLineGroup_zh_CN.ts
@@ -40,6 +40,108 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolyLineGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polylines)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polylines) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Line should have two points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;lid&quot; value in line %1. &quot;lid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolyLineGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/libs/geodata/polylinegroup/languages/iricGdPolyLineGroup_zh_TW.ts
+++ b/libs/geodata/polylinegroup/languages/iricGdPolyLineGroup_zh_TW.ts
@@ -40,6 +40,108 @@
     </message>
 </context>
 <context>
+    <name>GeoDataPolyLineGroupCsvExporter</name>
+    <message>
+        <source>CSV file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while exporting to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoDataPolyLineGroupCsvImporter</name>
+    <message>
+        <source>CSV file (Polylines)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSV file (Polylines) (*.csv)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while opening %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Header should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading header line. Column %1 should be &quot;%2&quot;, but &quot;%3&quot; is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. There is no data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Line should have two points at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Make sure the file is saved in UTF-8 encoding.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 5 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. Data should have 6 columns at least.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;lid&quot; value in line %1. &quot;lid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;vid&quot; value in line %1. &quot;vid&quot; should be integer value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;x&quot; value in line %1. &quot;x&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;y&quot; value in line %1. &quot;y&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading &quot;value&quot; value in line %1. &quot;value&quot; should be real value but &quot;%2&quot; is specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;name&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error occured while reading line %1. &quot;value&quot; should be the same for lines where &quot;lid&quot; values are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GeoDataPolyLineGroupShpExporter</name>
     <message>
         <source>ESRI Shapefile</source>

--- a/libs/geodata/polylinegroup/polylinegroup.pro
+++ b/libs/geodata/polylinegroup/polylinegroup.pro
@@ -144,6 +144,7 @@ HEADERS += gd_polylinegroup_global.h \
            geodatapolylinegroupcellmappert.h \
            geodatapolylinegroupcreator.h \
            geodatapolylinegroupcreatort.h \
+           geodatapolylinegroupcsvexporter.h \
            geodatapolylinegroupintegercreator.h \
            geodatapolylinegroupnodemappert.h \
            geodatapolylinegrouppolyline.h \
@@ -158,6 +159,7 @@ HEADERS += gd_polylinegroup_global.h \
 FORMS +=
 SOURCES += geodatapolylinegroup.cpp \
            geodatapolylinegroupcreator.cpp \
+           geodatapolylinegroupcsvexporter.cpp \
            geodatapolylinegroupintegercreator.cpp \
            geodatapolylinegrouppolyline.cpp \
            geodatapolylinegrouprealcreator.cpp \

--- a/libs/geodata/polylinegroup/polylinegroup.pro
+++ b/libs/geodata/polylinegroup/polylinegroup.pro
@@ -145,6 +145,7 @@ HEADERS += gd_polylinegroup_global.h \
            geodatapolylinegroupcreator.h \
            geodatapolylinegroupcreatort.h \
            geodatapolylinegroupcsvexporter.h \
+           geodatapolylinegroupcsvimporter.h \
            geodatapolylinegroupintegercreator.h \
            geodatapolylinegroupnodemappert.h \
            geodatapolylinegrouppolyline.h \
@@ -160,6 +161,7 @@ FORMS +=
 SOURCES += geodatapolylinegroup.cpp \
            geodatapolylinegroupcreator.cpp \
            geodatapolylinegroupcsvexporter.cpp \
+           geodatapolylinegroupcsvimporter.cpp \
            geodatapolylinegroupintegercreator.cpp \
            geodatapolylinegrouppolyline.cpp \
            geodatapolylinegrouprealcreator.cpp \


### PR DESCRIPTION
# Issue 817

Add function to export / import "Polygon group", "Polyline group", "Point group" from / to CSV files.

You can test with issue-817.zip attached to this.

# Issue 793

When a point in point group is selected, please select "Edit coordinates" from right-clicking menu.
Without the commits, nothing happens. On this branch, dialog to edit coordinate values are shown.

# Other issues

The following misc bugs are also fixed with this pull request:
* Offset values were not handled properly with "Point group", "Polyline group" and "Polygon group".
* When "Point group" is exported to shape files, offset values were not handled properly.  
* When a polyline in "Polyline group" is selected, "Add vertex", "Remove vertex", "Edit coordinates" menus are not enabled.

[issue-817.zip](https://github.com/i-RIC/prepost-gui/files/5371924/issue-817.zip)
