### PR TITLE
Close #915

### DIFF
--- a/libs/geodata/point/geodatapointcreator.cpp
+++ b/libs/geodata/point/geodatapointcreator.cpp
@@ -27,7 +27,6 @@ bool GeoDataPointCreator::isCreatable() const
 GeoData* GeoDataPointCreator::create(ProjectDataItem* parent, SolverDefinitionGridAttribute* condition)
 {
 	GeoDataPoint* point = new GeoDataPoint(parent, this, condition);
-	PreProcessorGeoDataDataItemInterface* item = dynamic_cast<PreProcessorGeoDataDataItemInterface*>(parent);
 	point->setPosition(condition->position());
 	point->setDefaultMapper();
 	return point;

--- a/libs/guibase/scalarbarsetting.cpp
+++ b/libs/guibase/scalarbarsetting.cpp
@@ -26,8 +26,8 @@ ScalarBarSetting::ScalarBarSetting() :
 	positionY {"positionY", 0.1},
 	labelFormat {"labelFormat", DEFAULT_LABELFORMAT}
 {
-	titleTextSetting.setPrefix("titleText");
-	labelTextSetting.setPrefix("labelText");
+	titleTextSetting.addPrefix("titleText");
+	labelTextSetting.addPrefix("labelText");
 }
 
 ScalarBarSetting::ScalarBarSetting(const ScalarBarSetting& setting) :

--- a/libs/guibase/scalarsettingcontainer.cpp
+++ b/libs/guibase/scalarsettingcontainer.cpp
@@ -14,7 +14,7 @@ ScalarSettingContainer::ScalarSettingContainer() :
 	scalarBarSetting {}
 {
 	opacity = 50;
-	scalarBarSetting.setPrefix("scalarBar");
+	scalarBarSetting.addPrefix("scalarBar");
 }
 
 ScalarSettingContainer::ScalarSettingContainer(const ScalarSettingContainer &c) :

--- a/libs/guibase/vtktextpropertysettingwidget.cpp
+++ b/libs/guibase/vtktextpropertysettingwidget.cpp
@@ -18,7 +18,7 @@ vtkTextPropertySettingWidget::~vtkTextPropertySettingWidget()
 vtkTextPropertySettingContainer vtkTextPropertySettingWidget::setting() const
 {
 	vtkTextPropertySettingContainer c;
-	c.setPrefix(m_prefix);
+	c.addPrefix(m_prefix);
 	c.fontFamily = static_cast<vtkTextPropertySettingContainer::FontFamily>(ui->fontComboBox->currentIndex());
 	c.fontSize = ui->sizeSpinBox->value();
 	c.fontColor = ui->colorWidget->color();

--- a/libs/misc/colorcontainer.cpp
+++ b/libs/misc/colorcontainer.cpp
@@ -102,9 +102,9 @@ const QString& ColorContainer::prefix() const
 	return impl->prefix();
 }
 
-void ColorContainer::setPrefix(const QString& prefix)
+void ColorContainer::addPrefix(const QString& prefix)
 {
-	impl->setPrefix(prefix);
+	impl->addPrefix(prefix);
 }
 
 QString ColorContainer::attName(const QString& name) const

--- a/libs/misc/colorcontainer.h
+++ b/libs/misc/colorcontainer.h
@@ -40,7 +40,7 @@ public:
 	/// @name Prefix
 	//@{
 	const QString& prefix() const override;
-	void setPrefix(const QString& prefix) override;
+	void addPrefix(const QString& prefix) override;
 	/// Attributes name (Prefix added if set)
 	QString attName(const QString& name) const override;
 	//@}

--- a/libs/misc/compositecontainer.cpp
+++ b/libs/misc/compositecontainer.cpp
@@ -26,11 +26,11 @@ void CompositeContainer::save(QXmlStreamWriter& writer) const
 	}
 }
 
-void CompositeContainer::setPrefix(const QString& prefix)
+void CompositeContainer::addPrefix(const QString& prefix)
 {
-	XmlAttributeContainer::setPrefix(prefix);
+	XmlAttributeContainer::addPrefix(prefix);
 	for (XmlAttributeContainer* c : impl->m_containers) {
-		c->setPrefix(prefix);
+		c->addPrefix(prefix);
 	}
 }
 

--- a/libs/misc/compositecontainer.h
+++ b/libs/misc/compositecontainer.h
@@ -22,8 +22,8 @@ public:
 
 	/// @name Property setting functions
 	//@{
-	/// Set prefix for XML attributes
-	void setPrefix(const QString& prefix) override;
+	/// Add prefix for XML attributes
+	void addPrefix(const QString& prefix) override;
 	//@}
 
 protected:

--- a/libs/misc/qpointfcontainer.cpp
+++ b/libs/misc/qpointfcontainer.cpp
@@ -9,7 +9,7 @@ QPointFContainer::QPointFContainer() :
 QPointFContainer::QPointFContainer(const QString& name) :
 	QPointFContainer {}
 {
-	setPrefix(name);
+	addPrefix(name);
 }
 
 QPointFContainer::QPointFContainer(const QPointF& val) :
@@ -93,11 +93,11 @@ void QPointFContainer::setValue(const QPointF& val)
 	impl->m_yValue = val.y();
 }
 
-void QPointFContainer::setPrefix(const QString& prefix)
+void QPointFContainer::addPrefix(const QString& prefix)
 {
-	impl->m_xValue.setPrefix(prefix);
-	impl->m_yValue.setPrefix(prefix);
-	XmlAttributeContainer::setPrefix(prefix);
+	impl->m_xValue.addPrefix(prefix);
+	impl->m_yValue.addPrefix(prefix);
+	XmlAttributeContainer::addPrefix(prefix);
 }
 
 void QPointFContainer::copyValue(const XmlAttributeContainer& c)

--- a/libs/misc/qpointfcontainer.h
+++ b/libs/misc/qpointfcontainer.h
@@ -42,7 +42,7 @@ public:
 	void setValue(const QPointF& val);
 	//@}
 
-	void setPrefix(const QString& prefix) override;
+	void addPrefix(const QString& prefix) override;
 
 private:
 	void copyValue(const XmlAttributeContainer& c) override;

--- a/libs/misc/xmlattributecontainer.cpp
+++ b/libs/misc/xmlattributecontainer.cpp
@@ -1,7 +1,11 @@
 #include "xmlattributecontainer.h"
 #include "private/xmlattributecontainer_impl.h"
 
+#include <misc/stringtool.h>
+
 #include <QString>
+
+#include <string>
 
 XmlAttributeContainer::XmlAttributeContainer() :
 	impl {new Impl {}}
@@ -30,18 +34,30 @@ const QString& XmlAttributeContainer::prefix() const
 	return impl->m_prefix;
 }
 
-void XmlAttributeContainer::setPrefix(const QString& prefix)
+void XmlAttributeContainer::addPrefix(const QString& prefix)
 {
-	impl->m_prefix = prefix;
+	if (impl->m_prefix.isEmpty()) {
+		impl->m_prefix = prefix;
+	} else {
+		QString newPrefix = prefix;
+		newPrefix.append(impl->m_prefix.left(1).toUpper());
+		newPrefix.append(impl->m_prefix.mid(1));
+		impl->m_prefix = newPrefix;
+	}
 }
 
 QString XmlAttributeContainer::attName(const QString& name) const
 {
+	std::string prefix = iRIC::toStr(impl->m_prefix);
+
 	if (impl->m_prefix.isEmpty()) {return name;}
 
 	QString fullName = impl->m_prefix;
 	fullName.append(name.left(1).toUpper());
 	fullName.append(name.mid(1));
+
+	std::string fn = iRIC::toStr(fullName);
+
 	return fullName;
 }
 

--- a/libs/misc/xmlattributecontainer.h
+++ b/libs/misc/xmlattributecontainer.h
@@ -32,7 +32,7 @@ public:
 	/// @name Property setting functions
 	//@{
 	virtual const QString& prefix() const;
-	virtual void setPrefix(const QString& prefix);
+	virtual void addPrefix(const QString& prefix);
 	virtual QString attName(const QString& name) const;
 	//@}
 

--- a/libs/post/post2d/datamodel/post2dwindowgraphsetting.cpp
+++ b/libs/post/post2d/datamodel/post2dwindowgraphsetting.cpp
@@ -22,10 +22,10 @@ Post2dWindowGraphSetting::Post2dWindowGraphSetting() :
 	graphLineStyle {},
 	graphValueFix {"valueFix", NoFix}
 {
-	gridLineStyle.setPrefix("grid");
+	gridLineStyle.addPrefix("grid");
 	gridLineStyle.color = Qt::gray;
 
-	graphLineStyle.setPrefix("graph");
+	graphLineStyle.addPrefix("graph");
 	graphLineStyle.color = Qt::black;
 }
 

--- a/libs/post/post2d/datamodel/post2dwindownodevectorarrowstructuredsetting.cpp
+++ b/libs/post/post2d/datamodel/post2dwindownodevectorarrowstructuredsetting.cpp
@@ -10,7 +10,7 @@ Post2dWindowNodeVectorArrowStructuredSetting::Post2dWindowNodeVectorArrowStructu
 	addContainer(&jSampleRate);
 	addContainer(&range);
 
-	range.setPrefix("region");
+	range.addPrefix("region");
 }
 
 Post2dWindowNodeVectorArrowStructuredSetting::Post2dWindowNodeVectorArrowStructuredSetting(const Post2dWindowNodeVectorArrowStructuredSetting &c) :

--- a/libs/post/post2d/datamodel/post2dwindownodevectorparticlegroupstructureddataitem.cpp
+++ b/libs/post/post2d/datamodel/post2dwindownodevectorparticlegroupstructureddataitem.cpp
@@ -26,7 +26,7 @@ Post2dWindowNodeVectorParticleGroupStructuredDataItem::Setting::Setting() :
 	QSettings settings;
 	color = settings.value("post2d/particlecolor", QColor(Qt::black)).value<QColor>();
 
-	range.setPrefix("region");
+	range.addPrefix("region");
 }
 
 Post2dWindowNodeVectorParticleGroupStructuredDataItem::Setting::Setting(const Setting& s) :

--- a/libs/post/post2d/datamodel/post2dwindownodevectorstreamlinegroupstructureddataitem.cpp
+++ b/libs/post/post2d/datamodel/post2dwindownodevectorstreamlinegroupstructureddataitem.cpp
@@ -28,7 +28,7 @@ Post2dWindowNodeVectorStreamlineGroupStructuredDataItem::Setting::Setting() :
 	QSettings settings;
 	color = settings.value("post2d/particlecolor", QColor(Qt::black)).value<QColor>();
 
-	range.setPrefix("region");
+	range.addPrefix("region");
 }
 
 Post2dWindowNodeVectorStreamlineGroupStructuredDataItem::Setting::Setting(const Setting& s) :

--- a/libs/postbase/post2dwindowcontoursetting.cpp
+++ b/libs/postbase/post2dwindowcontoursetting.cpp
@@ -7,7 +7,7 @@ Post2dWindowContourSetting::Post2dWindowContourSetting() :
 	addContainer(&regionMode);
 	addContainer(&range);
 
-	range.setPrefix("region");
+	range.addPrefix("region");
 }
 
 Post2dWindowContourSetting::Post2dWindowContourSetting(const Post2dWindowContourSetting& s) :

--- a/libs/pre/datamodel/preprocessorgeodatatopdataitem.cpp
+++ b/libs/pre/datamodel/preprocessorgeodatatopdataitem.cpp
@@ -160,8 +160,8 @@ PreProcessorGeoDataTopDataItem::PreProcessorGeoDataTopDataItem(PreProcessorDataI
 	setSubPath("geographicdata");
 	buildReferenceInformationAttribute();
 
-	m_titleTextSetting.setPrefix("title");
-	m_labelTextSetting.setPrefix("label");
+	m_titleTextSetting.addPrefix("title");
+	m_labelTextSetting.addPrefix("label");
 
 	if (gridType()->isKeepOrder()) {
 		setupChildrenInOrder(gridType()->gridAttributes(), gridType()->gridComplexAttributes(), &m_childItems, &m_itemNameMap, m_referenceInformationAttribute, this);


### PR DESCRIPTION
Without this branch when project file is saved with post2d window, \<ScalarGroup/\> element had two "scalarBarFontFamily" attributes.

With this branch, the attribute names are now "scalarBarTitleTextFontFamily" and "scalarBarLabelTextFontFamily", no duplication.