### PR TITLE
Force iricGdPolyline build to finish before iricGdPolylineGroup starts

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -101,6 +101,7 @@ before_build:
   - qmake -recursive -tp vc
 
 build_script:
+  - msbuild /nologo /verbosity:minimal /maxCpuCount /target:iricGdPolyline /p:Configuration=%Configuration% src.sln
   - msbuild /nologo /verbosity:minimal /maxCpuCount /p:Configuration=%Configuration% src.sln
 
 after_build:


### PR DESCRIPTION
Sometimes on appveyor, the build fails when iricGdPolylineGroup tries to link to iricGdPolyline.lib before is has finished building.  This change forces iricGdPolyline.lib to finish building before iricGdPolylineGroup starts building.