### PR TITLE
Improvements and bug fixes of RivMaker and iRIC, related to comments from USGS

### DIFF
--- a/apps/rivmaker/data/base/topview.cpp
+++ b/apps/rivmaker/data/base/topview.cpp
@@ -63,7 +63,13 @@ void TopView::paramsFit()
 	double centerX = 0, centerY = 0;
 	double width = 1, height = 1;
 
-	QRectF bb = model()->rootDataItemView()->boundingBox();
+	QRectF bb;
+	auto view = model()->rootDataItemView();
+
+	if (view != nullptr) {
+		bb = view->boundingBox();
+	}
+
 	if (! bb.isNull()) {
 		auto c = bb.center();
 		centerX = c.x();

--- a/apps/rivmaker/languages/rivmaker_ar_EG.ts
+++ b/apps/rivmaker/languages/rivmaker_ar_EG.ts
@@ -12,11 +12,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>rivmaker 2.0</source>
+        <source>rivmaker 2.0.2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Release Date: 2021/1/30</source>
+        <source>Release Date: 2021/3/2</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -98,7 +98,7 @@
 <context>
     <name>ChartGraphicsView</name>
     <message>
-        <source>Aspect ratio: 1 / %1</source>
+        <source>Aspect ratio (V/H): 1 / %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -125,15 +125,15 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Aspect ratio: 1 / </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Fix aspect ratio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Fix region</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Aspect ratio (V/H): 1 / </source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/apps/rivmaker/languages/rivmaker_bg_BG.ts
+++ b/apps/rivmaker/languages/rivmaker_bg_BG.ts
@@ -12,11 +12,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>rivmaker 2.0</source>
+        <source>rivmaker 2.0.2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Release Date: 2021/1/30</source>
+        <source>Release Date: 2021/3/2</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -98,7 +98,7 @@
 <context>
     <name>ChartGraphicsView</name>
     <message>
-        <source>Aspect ratio: 1 / %1</source>
+        <source>Aspect ratio (V/H): 1 / %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -125,15 +125,15 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Aspect ratio: 1 / </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Fix aspect ratio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Fix region</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Aspect ratio (V/H): 1 / </source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/apps/rivmaker/languages/rivmaker_bs_BA.ts
+++ b/apps/rivmaker/languages/rivmaker_bs_BA.ts
@@ -12,11 +12,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>rivmaker 2.0</source>
+        <source>rivmaker 2.0.2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Release Date: 2021/1/30</source>
+        <source>Release Date: 2021/3/2</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -98,7 +98,7 @@
 <context>
     <name>ChartGraphicsView</name>
     <message>
-        <source>Aspect ratio: 1 / %1</source>
+        <source>Aspect ratio (V/H): 1 / %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -125,15 +125,15 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Aspect ratio: 1 / </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Fix aspect ratio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Fix region</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Aspect ratio (V/H): 1 / </source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/apps/rivmaker/languages/rivmaker_ca_ES.ts
+++ b/apps/rivmaker/languages/rivmaker_ca_ES.ts
@@ -12,11 +12,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>rivmaker 2.0</source>
+        <source>rivmaker 2.0.2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Release Date: 2021/1/30</source>
+        <source>Release Date: 2021/3/2</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -98,7 +98,7 @@
 <context>
     <name>ChartGraphicsView</name>
     <message>
-        <source>Aspect ratio: 1 / %1</source>
+        <source>Aspect ratio (V/H): 1 / %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -125,15 +125,15 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Aspect ratio: 1 / </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Fix aspect ratio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Fix region</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Aspect ratio (V/H): 1 / </source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/apps/rivmaker/languages/rivmaker_cs_CZ.ts
+++ b/apps/rivmaker/languages/rivmaker_cs_CZ.ts
@@ -12,11 +12,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>rivmaker 2.0</source>
+        <source>rivmaker 2.0.2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Release Date: 2021/1/30</source>
+        <source>Release Date: 2021/3/2</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -98,7 +98,7 @@
 <context>
     <name>ChartGraphicsView</name>
     <message>
-        <source>Aspect ratio: 1 / %1</source>
+        <source>Aspect ratio (V/H): 1 / %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -125,15 +125,15 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Aspect ratio: 1 / </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Fix aspect ratio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Fix region</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Aspect ratio (V/H): 1 / </source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/apps/rivmaker/languages/rivmaker_da_DK.ts
+++ b/apps/rivmaker/languages/rivmaker_da_DK.ts
@@ -12,11 +12,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>rivmaker 2.0</source>
+        <source>rivmaker 2.0.2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Release Date: 2021/1/30</source>
+        <source>Release Date: 2021/3/2</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -98,7 +98,7 @@
 <context>
     <name>ChartGraphicsView</name>
     <message>
-        <source>Aspect ratio: 1 / %1</source>
+        <source>Aspect ratio (V/H): 1 / %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -125,15 +125,15 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Aspect ratio: 1 / </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Fix aspect ratio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Fix region</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Aspect ratio (V/H): 1 / </source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/apps/rivmaker/languages/rivmaker_de_DE.ts
+++ b/apps/rivmaker/languages/rivmaker_de_DE.ts
@@ -12,11 +12,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>rivmaker 2.0</source>
+        <source>rivmaker 2.0.2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Release Date: 2021/1/30</source>
+        <source>Release Date: 2021/3/2</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -98,7 +98,7 @@
 <context>
     <name>ChartGraphicsView</name>
     <message>
-        <source>Aspect ratio: 1 / %1</source>
+        <source>Aspect ratio (V/H): 1 / %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -125,15 +125,15 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Aspect ratio: 1 / </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Fix aspect ratio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Fix region</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Aspect ratio (V/H): 1 / </source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/apps/rivmaker/languages/rivmaker_el_GR.ts
+++ b/apps/rivmaker/languages/rivmaker_el_GR.ts
@@ -12,11 +12,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>rivmaker 2.0</source>
+        <source>rivmaker 2.0.2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Release Date: 2021/1/30</source>
+        <source>Release Date: 2021/3/2</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -98,7 +98,7 @@
 <context>
     <name>ChartGraphicsView</name>
     <message>
-        <source>Aspect ratio: 1 / %1</source>
+        <source>Aspect ratio (V/H): 1 / %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -125,15 +125,15 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Aspect ratio: 1 / </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Fix aspect ratio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Fix region</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Aspect ratio (V/H): 1 / </source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/apps/rivmaker/languages/rivmaker_es_ES.ts
+++ b/apps/rivmaker/languages/rivmaker_es_ES.ts
@@ -12,11 +12,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>rivmaker 2.0</source>
+        <source>rivmaker 2.0.2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Release Date: 2021/1/30</source>
+        <source>Release Date: 2021/3/2</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -98,7 +98,7 @@
 <context>
     <name>ChartGraphicsView</name>
     <message>
-        <source>Aspect ratio: 1 / %1</source>
+        <source>Aspect ratio (V/H): 1 / %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -125,15 +125,15 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Aspect ratio: 1 / </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Fix aspect ratio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Fix region</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Aspect ratio (V/H): 1 / </source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/apps/rivmaker/languages/rivmaker_et_EE.ts
+++ b/apps/rivmaker/languages/rivmaker_et_EE.ts
@@ -12,11 +12,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>rivmaker 2.0</source>
+        <source>rivmaker 2.0.2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Release Date: 2021/1/30</source>
+        <source>Release Date: 2021/3/2</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -98,7 +98,7 @@
 <context>
     <name>ChartGraphicsView</name>
     <message>
-        <source>Aspect ratio: 1 / %1</source>
+        <source>Aspect ratio (V/H): 1 / %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -125,15 +125,15 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Aspect ratio: 1 / </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Fix aspect ratio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Fix region</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Aspect ratio (V/H): 1 / </source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/apps/rivmaker/languages/rivmaker_eu_ES.ts
+++ b/apps/rivmaker/languages/rivmaker_eu_ES.ts
@@ -12,11 +12,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>rivmaker 2.0</source>
+        <source>rivmaker 2.0.2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Release Date: 2021/1/30</source>
+        <source>Release Date: 2021/3/2</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -98,7 +98,7 @@
 <context>
     <name>ChartGraphicsView</name>
     <message>
-        <source>Aspect ratio: 1 / %1</source>
+        <source>Aspect ratio (V/H): 1 / %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -125,15 +125,15 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Aspect ratio: 1 / </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Fix aspect ratio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Fix region</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Aspect ratio (V/H): 1 / </source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/apps/rivmaker/languages/rivmaker_fi_FI.ts
+++ b/apps/rivmaker/languages/rivmaker_fi_FI.ts
@@ -12,11 +12,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>rivmaker 2.0</source>
+        <source>rivmaker 2.0.2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Release Date: 2021/1/30</source>
+        <source>Release Date: 2021/3/2</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -98,7 +98,7 @@
 <context>
     <name>ChartGraphicsView</name>
     <message>
-        <source>Aspect ratio: 1 / %1</source>
+        <source>Aspect ratio (V/H): 1 / %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -125,15 +125,15 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Aspect ratio: 1 / </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Fix aspect ratio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Fix region</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Aspect ratio (V/H): 1 / </source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/apps/rivmaker/languages/rivmaker_fr_FR.ts
+++ b/apps/rivmaker/languages/rivmaker_fr_FR.ts
@@ -12,11 +12,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>rivmaker 2.0</source>
+        <source>rivmaker 2.0.2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Release Date: 2021/1/30</source>
+        <source>Release Date: 2021/3/2</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -98,7 +98,7 @@
 <context>
     <name>ChartGraphicsView</name>
     <message>
-        <source>Aspect ratio: 1 / %1</source>
+        <source>Aspect ratio (V/H): 1 / %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -125,15 +125,15 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Aspect ratio: 1 / </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Fix aspect ratio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Fix region</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Aspect ratio (V/H): 1 / </source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/apps/rivmaker/languages/rivmaker_gl_ES.ts
+++ b/apps/rivmaker/languages/rivmaker_gl_ES.ts
@@ -12,11 +12,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>rivmaker 2.0</source>
+        <source>rivmaker 2.0.2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Release Date: 2021/1/30</source>
+        <source>Release Date: 2021/3/2</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -98,7 +98,7 @@
 <context>
     <name>ChartGraphicsView</name>
     <message>
-        <source>Aspect ratio: 1 / %1</source>
+        <source>Aspect ratio (V/H): 1 / %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -125,15 +125,15 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Aspect ratio: 1 / </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Fix aspect ratio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Fix region</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Aspect ratio (V/H): 1 / </source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/apps/rivmaker/languages/rivmaker_hi_IN.ts
+++ b/apps/rivmaker/languages/rivmaker_hi_IN.ts
@@ -12,11 +12,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>rivmaker 2.0</source>
+        <source>rivmaker 2.0.2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Release Date: 2021/1/30</source>
+        <source>Release Date: 2021/3/2</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -98,7 +98,7 @@
 <context>
     <name>ChartGraphicsView</name>
     <message>
-        <source>Aspect ratio: 1 / %1</source>
+        <source>Aspect ratio (V/H): 1 / %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -125,15 +125,15 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Aspect ratio: 1 / </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Fix aspect ratio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Fix region</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Aspect ratio (V/H): 1 / </source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/apps/rivmaker/languages/rivmaker_hu_HU.ts
+++ b/apps/rivmaker/languages/rivmaker_hu_HU.ts
@@ -12,11 +12,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>rivmaker 2.0</source>
+        <source>rivmaker 2.0.2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Release Date: 2021/1/30</source>
+        <source>Release Date: 2021/3/2</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -98,7 +98,7 @@
 <context>
     <name>ChartGraphicsView</name>
     <message>
-        <source>Aspect ratio: 1 / %1</source>
+        <source>Aspect ratio (V/H): 1 / %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -125,15 +125,15 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Aspect ratio: 1 / </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Fix aspect ratio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Fix region</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Aspect ratio (V/H): 1 / </source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/apps/rivmaker/languages/rivmaker_id_ID.ts
+++ b/apps/rivmaker/languages/rivmaker_id_ID.ts
@@ -12,11 +12,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>rivmaker 2.0</source>
+        <source>rivmaker 2.0.2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Release Date: 2021/1/30</source>
+        <source>Release Date: 2021/3/2</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -98,7 +98,7 @@
 <context>
     <name>ChartGraphicsView</name>
     <message>
-        <source>Aspect ratio: 1 / %1</source>
+        <source>Aspect ratio (V/H): 1 / %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -125,15 +125,15 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Aspect ratio: 1 / </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Fix aspect ratio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Fix region</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Aspect ratio (V/H): 1 / </source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/apps/rivmaker/languages/rivmaker_is_IS.ts
+++ b/apps/rivmaker/languages/rivmaker_is_IS.ts
@@ -12,11 +12,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>rivmaker 2.0</source>
+        <source>rivmaker 2.0.2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Release Date: 2021/1/30</source>
+        <source>Release Date: 2021/3/2</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -98,7 +98,7 @@
 <context>
     <name>ChartGraphicsView</name>
     <message>
-        <source>Aspect ratio: 1 / %1</source>
+        <source>Aspect ratio (V/H): 1 / %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -125,15 +125,15 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Aspect ratio: 1 / </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Fix aspect ratio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Fix region</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Aspect ratio (V/H): 1 / </source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/apps/rivmaker/languages/rivmaker_it_IT.ts
+++ b/apps/rivmaker/languages/rivmaker_it_IT.ts
@@ -12,11 +12,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>rivmaker 2.0</source>
+        <source>rivmaker 2.0.2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Release Date: 2021/1/30</source>
+        <source>Release Date: 2021/3/2</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -98,7 +98,7 @@
 <context>
     <name>ChartGraphicsView</name>
     <message>
-        <source>Aspect ratio: 1 / %1</source>
+        <source>Aspect ratio (V/H): 1 / %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -125,15 +125,15 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Aspect ratio: 1 / </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Fix aspect ratio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Fix region</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Aspect ratio (V/H): 1 / </source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/apps/rivmaker/languages/rivmaker_ja_JP.ts
+++ b/apps/rivmaker/languages/rivmaker_ja_JP.ts
@@ -21,11 +21,19 @@
     </message>
     <message>
         <source>rivmaker 2.0</source>
-        <translation>rivmaker 2.0</translation>
+        <translation type="vanished">rivmaker 2.0</translation>
     </message>
     <message>
         <source>Release Date: 2021/1/30</source>
-        <translation>リリース日: 2021/1/30</translation>
+        <translation type="vanished">リリース日: 2021/1/30</translation>
+    </message>
+    <message>
+        <source>rivmaker 2.0.2</source>
+        <translation>rivmaker 2.0.2</translation>
+    </message>
+    <message>
+        <source>Release Date: 2021/3/2</source>
+        <translation>リリース日: 2021/3/2</translation>
     </message>
 </context>
 <context>
@@ -107,7 +115,11 @@
     <name>ChartGraphicsView</name>
     <message>
         <source>Aspect ratio: 1 / %1</source>
-        <translation>縦横比 1 / %1</translation>
+        <translation type="vanished">縦横比 1 / %1</translation>
+    </message>
+    <message>
+        <source>Aspect ratio (V/H): 1 / %1</source>
+        <translation>縦横比: 1 / %1</translation>
     </message>
 </context>
 <context>
@@ -134,7 +146,7 @@
     </message>
     <message>
         <source>Aspect ratio: 1 / </source>
-        <translation>縦横比: 1 / </translation>
+        <translation type="vanished">縦横比: 1 / </translation>
     </message>
     <message>
         <source>Fix aspect ratio</source>
@@ -143,6 +155,10 @@
     <message>
         <source>Fix region</source>
         <translation>領域を固定</translation>
+    </message>
+    <message>
+        <source>Aspect ratio (V/H): 1 / </source>
+        <translation>縦横比 1 / </translation>
     </message>
 </context>
 <context>

--- a/apps/rivmaker/languages/rivmaker_ko_KR.ts
+++ b/apps/rivmaker/languages/rivmaker_ko_KR.ts
@@ -12,11 +12,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>rivmaker 2.0</source>
+        <source>rivmaker 2.0.2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Release Date: 2021/1/30</source>
+        <source>Release Date: 2021/3/2</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -98,7 +98,7 @@
 <context>
     <name>ChartGraphicsView</name>
     <message>
-        <source>Aspect ratio: 1 / %1</source>
+        <source>Aspect ratio (V/H): 1 / %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -125,15 +125,15 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Aspect ratio: 1 / </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Fix aspect ratio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Fix region</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Aspect ratio (V/H): 1 / </source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/apps/rivmaker/languages/rivmaker_ky_KG.ts
+++ b/apps/rivmaker/languages/rivmaker_ky_KG.ts
@@ -12,11 +12,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>rivmaker 2.0</source>
+        <source>rivmaker 2.0.2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Release Date: 2021/1/30</source>
+        <source>Release Date: 2021/3/2</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -98,7 +98,7 @@
 <context>
     <name>ChartGraphicsView</name>
     <message>
-        <source>Aspect ratio: 1 / %1</source>
+        <source>Aspect ratio (V/H): 1 / %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -125,15 +125,15 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Aspect ratio: 1 / </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Fix aspect ratio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Fix region</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Aspect ratio (V/H): 1 / </source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/apps/rivmaker/languages/rivmaker_lt_LT.ts
+++ b/apps/rivmaker/languages/rivmaker_lt_LT.ts
@@ -12,11 +12,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>rivmaker 2.0</source>
+        <source>rivmaker 2.0.2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Release Date: 2021/1/30</source>
+        <source>Release Date: 2021/3/2</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -98,7 +98,7 @@
 <context>
     <name>ChartGraphicsView</name>
     <message>
-        <source>Aspect ratio: 1 / %1</source>
+        <source>Aspect ratio (V/H): 1 / %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -125,15 +125,15 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Aspect ratio: 1 / </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Fix aspect ratio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Fix region</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Aspect ratio (V/H): 1 / </source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/apps/rivmaker/languages/rivmaker_lv_LV.ts
+++ b/apps/rivmaker/languages/rivmaker_lv_LV.ts
@@ -12,11 +12,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>rivmaker 2.0</source>
+        <source>rivmaker 2.0.2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Release Date: 2021/1/30</source>
+        <source>Release Date: 2021/3/2</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -98,7 +98,7 @@
 <context>
     <name>ChartGraphicsView</name>
     <message>
-        <source>Aspect ratio: 1 / %1</source>
+        <source>Aspect ratio (V/H): 1 / %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -125,15 +125,15 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Aspect ratio: 1 / </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Fix aspect ratio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Fix region</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Aspect ratio (V/H): 1 / </source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/apps/rivmaker/languages/rivmaker_nb_NO.ts
+++ b/apps/rivmaker/languages/rivmaker_nb_NO.ts
@@ -12,11 +12,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>rivmaker 2.0</source>
+        <source>rivmaker 2.0.2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Release Date: 2021/1/30</source>
+        <source>Release Date: 2021/3/2</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -98,7 +98,7 @@
 <context>
     <name>ChartGraphicsView</name>
     <message>
-        <source>Aspect ratio: 1 / %1</source>
+        <source>Aspect ratio (V/H): 1 / %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -125,15 +125,15 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Aspect ratio: 1 / </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Fix aspect ratio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Fix region</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Aspect ratio (V/H): 1 / </source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/apps/rivmaker/languages/rivmaker_nl_NL.ts
+++ b/apps/rivmaker/languages/rivmaker_nl_NL.ts
@@ -12,11 +12,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>rivmaker 2.0</source>
+        <source>rivmaker 2.0.2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Release Date: 2021/1/30</source>
+        <source>Release Date: 2021/3/2</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -98,7 +98,7 @@
 <context>
     <name>ChartGraphicsView</name>
     <message>
-        <source>Aspect ratio: 1 / %1</source>
+        <source>Aspect ratio (V/H): 1 / %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -125,15 +125,15 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Aspect ratio: 1 / </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Fix aspect ratio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Fix region</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Aspect ratio (V/H): 1 / </source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/apps/rivmaker/languages/rivmaker_pl_PL.ts
+++ b/apps/rivmaker/languages/rivmaker_pl_PL.ts
@@ -12,11 +12,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>rivmaker 2.0</source>
+        <source>rivmaker 2.0.2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Release Date: 2021/1/30</source>
+        <source>Release Date: 2021/3/2</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -98,7 +98,7 @@
 <context>
     <name>ChartGraphicsView</name>
     <message>
-        <source>Aspect ratio: 1 / %1</source>
+        <source>Aspect ratio (V/H): 1 / %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -125,15 +125,15 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Aspect ratio: 1 / </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Fix aspect ratio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Fix region</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Aspect ratio (V/H): 1 / </source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/apps/rivmaker/languages/rivmaker_pt_BR.ts
+++ b/apps/rivmaker/languages/rivmaker_pt_BR.ts
@@ -12,11 +12,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>rivmaker 2.0</source>
+        <source>rivmaker 2.0.2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Release Date: 2021/1/30</source>
+        <source>Release Date: 2021/3/2</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -98,7 +98,7 @@
 <context>
     <name>ChartGraphicsView</name>
     <message>
-        <source>Aspect ratio: 1 / %1</source>
+        <source>Aspect ratio (V/H): 1 / %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -125,15 +125,15 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Aspect ratio: 1 / </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Fix aspect ratio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Fix region</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Aspect ratio (V/H): 1 / </source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/apps/rivmaker/languages/rivmaker_pt_PT.ts
+++ b/apps/rivmaker/languages/rivmaker_pt_PT.ts
@@ -12,11 +12,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>rivmaker 2.0</source>
+        <source>rivmaker 2.0.2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Release Date: 2021/1/30</source>
+        <source>Release Date: 2021/3/2</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -98,7 +98,7 @@
 <context>
     <name>ChartGraphicsView</name>
     <message>
-        <source>Aspect ratio: 1 / %1</source>
+        <source>Aspect ratio (V/H): 1 / %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -125,15 +125,15 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Aspect ratio: 1 / </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Fix aspect ratio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Fix region</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Aspect ratio (V/H): 1 / </source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/apps/rivmaker/languages/rivmaker_ro_RO.ts
+++ b/apps/rivmaker/languages/rivmaker_ro_RO.ts
@@ -12,11 +12,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>rivmaker 2.0</source>
+        <source>rivmaker 2.0.2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Release Date: 2021/1/30</source>
+        <source>Release Date: 2021/3/2</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -98,7 +98,7 @@
 <context>
     <name>ChartGraphicsView</name>
     <message>
-        <source>Aspect ratio: 1 / %1</source>
+        <source>Aspect ratio (V/H): 1 / %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -125,15 +125,15 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Aspect ratio: 1 / </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Fix aspect ratio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Fix region</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Aspect ratio (V/H): 1 / </source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/apps/rivmaker/languages/rivmaker_ru_RU.ts
+++ b/apps/rivmaker/languages/rivmaker_ru_RU.ts
@@ -12,11 +12,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>rivmaker 2.0</source>
+        <source>rivmaker 2.0.2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Release Date: 2021/1/30</source>
+        <source>Release Date: 2021/3/2</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -98,7 +98,7 @@
 <context>
     <name>ChartGraphicsView</name>
     <message>
-        <source>Aspect ratio: 1 / %1</source>
+        <source>Aspect ratio (V/H): 1 / %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -125,15 +125,15 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Aspect ratio: 1 / </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Fix aspect ratio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Fix region</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Aspect ratio (V/H): 1 / </source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/apps/rivmaker/languages/rivmaker_sl_SI.ts
+++ b/apps/rivmaker/languages/rivmaker_sl_SI.ts
@@ -12,11 +12,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>rivmaker 2.0</source>
+        <source>rivmaker 2.0.2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Release Date: 2021/1/30</source>
+        <source>Release Date: 2021/3/2</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -98,7 +98,7 @@
 <context>
     <name>ChartGraphicsView</name>
     <message>
-        <source>Aspect ratio: 1 / %1</source>
+        <source>Aspect ratio (V/H): 1 / %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -125,15 +125,15 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Aspect ratio: 1 / </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Fix aspect ratio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Fix region</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Aspect ratio (V/H): 1 / </source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/apps/rivmaker/languages/rivmaker_sv_SE.ts
+++ b/apps/rivmaker/languages/rivmaker_sv_SE.ts
@@ -12,11 +12,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>rivmaker 2.0</source>
+        <source>rivmaker 2.0.2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Release Date: 2021/1/30</source>
+        <source>Release Date: 2021/3/2</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -98,7 +98,7 @@
 <context>
     <name>ChartGraphicsView</name>
     <message>
-        <source>Aspect ratio: 1 / %1</source>
+        <source>Aspect ratio (V/H): 1 / %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -125,15 +125,15 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Aspect ratio: 1 / </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Fix aspect ratio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Fix region</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Aspect ratio (V/H): 1 / </source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/apps/rivmaker/languages/rivmaker_th_TH.ts
+++ b/apps/rivmaker/languages/rivmaker_th_TH.ts
@@ -12,11 +12,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>rivmaker 2.0</source>
+        <source>rivmaker 2.0.2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Release Date: 2021/1/30</source>
+        <source>Release Date: 2021/3/2</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -98,7 +98,7 @@
 <context>
     <name>ChartGraphicsView</name>
     <message>
-        <source>Aspect ratio: 1 / %1</source>
+        <source>Aspect ratio (V/H): 1 / %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -125,15 +125,15 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Aspect ratio: 1 / </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Fix aspect ratio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Fix region</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Aspect ratio (V/H): 1 / </source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/apps/rivmaker/languages/rivmaker_tr_TR.ts
+++ b/apps/rivmaker/languages/rivmaker_tr_TR.ts
@@ -12,11 +12,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>rivmaker 2.0</source>
+        <source>rivmaker 2.0.2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Release Date: 2021/1/30</source>
+        <source>Release Date: 2021/3/2</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -98,7 +98,7 @@
 <context>
     <name>ChartGraphicsView</name>
     <message>
-        <source>Aspect ratio: 1 / %1</source>
+        <source>Aspect ratio (V/H): 1 / %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -125,15 +125,15 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Aspect ratio: 1 / </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Fix aspect ratio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Fix region</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Aspect ratio (V/H): 1 / </source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/apps/rivmaker/languages/rivmaker_uk_UA.ts
+++ b/apps/rivmaker/languages/rivmaker_uk_UA.ts
@@ -12,11 +12,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>rivmaker 2.0</source>
+        <source>rivmaker 2.0.2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Release Date: 2021/1/30</source>
+        <source>Release Date: 2021/3/2</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -98,7 +98,7 @@
 <context>
     <name>ChartGraphicsView</name>
     <message>
-        <source>Aspect ratio: 1 / %1</source>
+        <source>Aspect ratio (V/H): 1 / %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -125,15 +125,15 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Aspect ratio: 1 / </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Fix aspect ratio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Fix region</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Aspect ratio (V/H): 1 / </source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/apps/rivmaker/languages/rivmaker_vi_VN.ts
+++ b/apps/rivmaker/languages/rivmaker_vi_VN.ts
@@ -12,11 +12,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>rivmaker 2.0</source>
+        <source>rivmaker 2.0.2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Release Date: 2021/1/30</source>
+        <source>Release Date: 2021/3/2</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -98,7 +98,7 @@
 <context>
     <name>ChartGraphicsView</name>
     <message>
-        <source>Aspect ratio: 1 / %1</source>
+        <source>Aspect ratio (V/H): 1 / %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -125,15 +125,15 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Aspect ratio: 1 / </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Fix aspect ratio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Fix region</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Aspect ratio (V/H): 1 / </source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/apps/rivmaker/languages/rivmaker_zh_CN.ts
+++ b/apps/rivmaker/languages/rivmaker_zh_CN.ts
@@ -16,12 +16,16 @@
         <translation>版权: USGS</translation>
     </message>
     <message>
-        <source>rivmaker 2.0</source>
+        <source>Release Date: 2021/1/30</source>
+        <translation type="obsolete">发布日期: 2021/1/30</translation>
+    </message>
+    <message>
+        <source>rivmaker 2.0.2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Release Date: 2021/1/30</source>
-        <translation type="unfinished">发布日期: 2021/1/30</translation>
+        <source>Release Date: 2021/3/2</source>
+        <translation type="unfinished">发布日期: 2021/3/2</translation>
     </message>
 </context>
 <context>
@@ -102,7 +106,7 @@
 <context>
     <name>ChartGraphicsView</name>
     <message>
-        <source>Aspect ratio: 1 / %1</source>
+        <source>Aspect ratio (V/H): 1 / %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -129,15 +133,15 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Aspect ratio: 1 / </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Fix aspect ratio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Fix region</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Aspect ratio (V/H): 1 / </source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/apps/rivmaker/languages/rivmaker_zh_TW.ts
+++ b/apps/rivmaker/languages/rivmaker_zh_TW.ts
@@ -12,11 +12,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>rivmaker 2.0</source>
+        <source>rivmaker 2.0.2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Release Date: 2021/1/30</source>
+        <source>Release Date: 2021/3/2</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -98,7 +98,7 @@
 <context>
     <name>ChartGraphicsView</name>
     <message>
-        <source>Aspect ratio: 1 / %1</source>
+        <source>Aspect ratio (V/H): 1 / %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -125,15 +125,15 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Aspect ratio: 1 / </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Fix aspect ratio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Fix region</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Aspect ratio (V/H): 1 / </source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/apps/rivmaker/main/rivmakermainwindow.cpp
+++ b/apps/rivmaker/main/rivmakermainwindow.cpp
@@ -611,6 +611,7 @@ void RivmakerMainWindow::deleteProject()
 {
 	delete impl->m_project;
 	impl->m_project = nullptr;
+	impl->m_preProcessorWindow.setProject(nullptr);
 	impl->m_verticalCrossSectionWindow.setProject(nullptr);
 	impl->m_mousePositionWidget.setProject(nullptr);
 }

--- a/apps/rivmaker/widgets/chartgraphicsview.cpp
+++ b/apps/rivmaker/widgets/chartgraphicsview.cpp
@@ -473,7 +473,7 @@ void ChartGraphicsView::drawAspectRatio(QPainter* painter)
 
 	QSize s = size();
 
-	auto str = tr("Aspect ratio: 1 / %1").arg(aspectRatio());
+	auto str = tr("Aspect ratio (V/H): 1 / %1").arg(aspectRatio());
 	QFontMetricsF metrics(painter->font());
 	auto rect = metrics.boundingRect(str);
 

--- a/apps/rivmaker/widgets/chartwindow.cpp
+++ b/apps/rivmaker/widgets/chartwindow.cpp
@@ -169,9 +169,6 @@ void ChartWindow::addViewToolBar()
 	connect(m_fixRegionCheckBox, SIGNAL(toggled(bool)), this, SLOT(updateAspectRatioStatus()));
 
 	addToolBar(m_viewToolBar);
-
-	m_fixAspectRatioCheckBox->setChecked(true);
-	setAspectRatio(5.0);
 }
 
 ChartGraphicsView* ChartWindow::graphicsView()

--- a/apps/rivmaker/widgets/chartwindow.cpp
+++ b/apps/rivmaker/widgets/chartwindow.cpp
@@ -145,7 +145,7 @@ void ChartWindow::addViewToolBar()
 {
 	m_viewToolBar = new QToolBar(tr("View ToolBar"), this);
 
-	auto l = new QLabel(tr("Aspect ratio: 1 / "), this);
+	auto l = new QLabel(tr("Aspect ratio (V/H): 1 / "), this);
 	m_viewToolBar->addWidget(l);
 
 	m_aspectRatioEdit = new QLineEdit(this);

--- a/apps/rivmaker/widgets/chartwindow.h
+++ b/apps/rivmaker/widgets/chartwindow.h
@@ -54,6 +54,8 @@ protected:
 	QToolBar* displayToolBar() const;
 	QToolBar* viewToolBar() const;
 
+	QCheckBox* m_fixAspectRatioCheckBox;
+
 private:
 	void addDisplayToolBar();
 	void addViewToolBar();
@@ -67,7 +69,6 @@ private:
 	QCheckBox* m_showScalesCheckBox;
 	QCheckBox* m_showAspectRatioCheckBox;
 	QLineEdit* m_aspectRatioEdit;
-	QCheckBox* m_fixAspectRatioCheckBox;
 	QCheckBox* m_fixRegionCheckBox;
 };
 

--- a/apps/rivmaker/window/crosssection/crosssectionwindow.cpp
+++ b/apps/rivmaker/window/crosssection/crosssectionwindow.cpp
@@ -205,6 +205,9 @@ void CrossSectionWindow::setupToolBars()
 
 	m_displaySettingButton = new QPushButton("&Display Setting", this);
 	tb->addWidget(m_displaySettingButton);
+
+	m_fixAspectRatioCheckBox->setChecked(true);
+	setAspectRatio(5.0);
 }
 
 void CrossSectionWindow::updateWindowTitle()

--- a/apps/rivmaker/window/preprocessor/preprocessormodel.cpp
+++ b/apps/rivmaker/window/preprocessor/preprocessormodel.cpp
@@ -273,5 +273,9 @@ void PreProcessorModel::setupStandatdItemModel()
 
 RootDataItem* PreProcessorModel::rootDataItem() const
 {
+	if (impl->m_project == nullptr) {
+		return nullptr;
+	}
+
 	return impl->m_project->rootDataItem();
 }

--- a/apps/rivmaker/window/preprocessor/preprocessorwindow.cpp
+++ b/apps/rivmaker/window/preprocessor/preprocessorwindow.cpp
@@ -52,6 +52,8 @@ PreProcessorWindow::~PreProcessorWindow()
 void PreProcessorWindow::setProject(Project* project)
 {
 	impl->m_model.setProject(project);
+	if (project == nullptr) {return;}
+
 	connect(project, SIGNAL(updated()), this, SLOT(update()));
 }
 

--- a/libs/geodata/riversurvey/geodatariversurveycrosssectionwindow.cpp
+++ b/libs/geodata/riversurvey/geodatariversurveycrosssectionwindow.cpp
@@ -207,7 +207,7 @@ void GeoDataRiverSurveyCrosssectionWindow::setupToolBars()
 	spacer->setFixedWidth(10);
 	ui->viewToolBar->addWidget(spacer);
 
-	l = new QLabel(tr("Aspect ratio: 1 / "), this);
+	l = new QLabel(tr("Aspect ratio (V/H): 1 / "), this);
 	ui->viewToolBar->addWidget(l);
 
 	impl->m_aspectRatioEdit = new RealNumberEditWidget(this);

--- a/libs/geodata/riversurvey/geodatariversurveycrosssectionwindowgraphicsview.cpp
+++ b/libs/geodata/riversurvey/geodatariversurveycrosssectionwindowgraphicsview.cpp
@@ -822,7 +822,7 @@ void GeoDataRiverSurveyCrosssectionWindowGraphicsView::drawAspectRatio(QPainter&
 
 	QSize windowSize = size();
 
-	auto aspectRatioStr = tr("Aspect ratio: 1 / %1").arg(aspectRatio());
+	auto aspectRatioStr = tr("Aspect ratio (V/H): 1 / %1").arg(aspectRatio());
 	QFontMetricsF metrics(painter.font());
 	auto rect = metrics.boundingRect(aspectRatioStr);
 

--- a/libs/gridcreatingcondition/riversurvey15d/gridcreatingconditionriversurvey15d.cpp
+++ b/libs/gridcreatingcondition/riversurvey15d/gridcreatingconditionriversurvey15d.cpp
@@ -181,21 +181,18 @@ private:
 	std::list<GeoDataRiverSurveyCtrlPointBackup*> m_after;
 };
 
-
 // constructor
-GridCreatingConditionRiverSurvey15D::GridCreatingConditionRiverSurvey15D(ProjectDataItem* parent, GridCreatingConditionCreator* creator)
-	: GridCreatingCondition(parent, creator)
+GridCreatingConditionRiverSurvey15D::GridCreatingConditionRiverSurvey15D(ProjectDataItem* parent, GridCreatingConditionCreator* creator) :
+	GridCreatingCondition(parent, creator),
+	m_lastStartPoint {nullptr},
+	m_lastEndPoint {nullptr},
+	m_lastRegionAddStartPoint {nullptr},
+	m_lastRegionAddEndPoint {nullptr},
+	m_positionMode {GridCreatingConditionRiverSurvey15DRegionDialog::PositionMode::LeftBank},
+	m_rightClickingMenu {nullptr},
+	m_mouseEventMode {meNormal}
 {
-	m_lastStartPoint = nullptr;
-	m_lastEndPoint = nullptr;
-
-	m_lastRegionAddStartPoint = nullptr;
-	m_lastRegionAddEndPoint = nullptr;
-	m_positionMode = GridCreatingConditionRiverSurvey15DRegionDialog::PositionMode::CenterPoint;
-
 	m_selectedZone.point = nullptr;
-	m_mouseEventMode = meNormal;
-	m_rightClickingMenu = nullptr;
 	setupVtkContainers();
 	setupActions();
 	setActionStatus();

--- a/plugins/gridexporter/structured15dgridwithcrosssectionhecrasexporter/structured15dgridwithcrosssectionhecrasexporter.cpp
+++ b/plugins/gridexporter/structured15dgridwithcrosssectionhecrasexporter/structured15dgridwithcrosssectionhecrasexporter.cpp
@@ -221,8 +221,8 @@ bool Structured15DGridWithCrossSectionHecRasExporter::doExport(Grid* grid, const
 		for (const Structured15DGridWithCrossSectionCrossSection::Altitude& alt : cs->altitudeInfo()) {
 			if (row_idx == 0) {
 				o.setFieldWidth(0);
-				o << "GR ";
-				o.setFieldWidth(5);
+				o << "GR";
+				o.setFieldWidth(6);
 				o << alt.m_height;
 				o.setFieldWidth(0);
 				o << " ";

--- a/plugins/gridexporter/structured15dgridwithcrosssectionhecrasexporter/structured15dgridwithcrosssectionhecrasexporter.cpp
+++ b/plugins/gridexporter/structured15dgridwithcrosssectionhecrasexporter/structured15dgridwithcrosssectionhecrasexporter.cpp
@@ -180,35 +180,47 @@ bool Structured15DGridWithCrossSectionHecRasExporter::doExport(Grid* grid, const
 			o.setFieldWidth(0);
 			o << endl;
 		} else {
+			std::vector<double> pos_vec2, n_vec2;
 			int idx = 0;
 			while (idx < pos_vec.size()) {
+				if (idx < n_vec.size() - 1 && n_vec.at(idx) == n_vec.at(idx + 1)) {
+					++ idx;
+					continue;
+				}
+				pos_vec2.push_back(pos_vec.at(idx));
+				n_vec2.push_back(n_vec.at(idx));
+				++ idx;
+			}
+
+			idx = 0;
+			while (idx < pos_vec2.size()) {
 				if (idx == 0) {
 					o.setFieldWidth(0);
 					o << "NH ";
 
 					o.setFieldWidth(5);
-					o << n_vec.size();
+					o << n_vec2.size();
 
 					outputSingleSpace(&o);
-					outputNValue(&o, n_vec.at(0));
+					outputNValue(&o, n_vec2.at(idx));
 
 					outputSingleSpace(&o);
-					outputPosValue(&o, pos_vec.at(0), 7);
+					outputPosValue(&o, pos_vec2.at(idx), 7);
 				} else if ((idx + 1) % 5 == 0) {
 					outputSingleSpace(&o);
-					outputNValue(&o, n_vec.at(idx));
+					outputNValue(&o, n_vec2.at(idx));
 
 					o.setFieldWidth(0);
 					o << endl;
 					o << "NH ";
 
-					outputPosValue(&o, pos_vec.at(idx), 5);
+					outputPosValue(&o, pos_vec2.at(idx), 5);
 				} else {
 					outputSingleSpace(&o);
-					outputNValue(&o, n_vec.at(idx));
+					outputNValue(&o, n_vec2.at(idx));
 
 					outputSingleSpace(&o);
-					outputPosValue(&o, pos_vec.at(idx), 7);
+					outputPosValue(&o, pos_vec2.at(idx), 7);
 				}
 				++ idx;
 			}


### PR DESCRIPTION
Bug fixes and improvements based on comments from USGS.

## Aspect ratio -> Aspect ratio (V/H)

In RivMaker, on "Cross Section Window" and "Elevation View Window",
"Aspect ratio" is changed to "Aspect ratio (V/H)".

You can check by importing sac_input.txt to RivMaker, for example.

## Elevation View Window is auto scaled

In RivMaker, when opened at first, the aspect ratio for "Elevation View Window" was fixed to 1 / 5, but now it is auto fitted.

## Issue 858 is closed

Please test using example_xs.zip attached to the following issue:

https://github.com/i-RIC/prepost-gui/issues/858

## The default value for "Position value of elevation points" is changed to "Distance from left bank" now.

In iRIC GUI, on "Grid Creation" dialog for creating grid for SAC, the default value for
"Position value for elevation points" is changed to "Distance from left bank".

You can test by the steps below:

1. Launch iRIC GUI, and starts a project for SAC.
2. Import test.riv attached to this pull request.
3. Creates a grid.

## HEC output function now works correctly with Elevation values larger than 1000

When HEC-RAS file is exported from iRIC GUI, the GR records are output correctly in cases elevation values are larger than 1000.

You can test by the steps below:

1. Launch iRIC GUI, and open test_large_GR.ipro
2. Export the grid with "HEC-RAS text files (*.dat)" filter.

Please notice that you need to copy structured15dgridwithcrosssectionhecrasexporter.dll to gridexporter_plugins\structured15dhecras folder manually.

## NH records are merged

Previously, NH records are output for every spans for the cross-section, but now merged for the same roughness values.

Please test by the steps below:

1. Launch iRIC GUI, and open test_NH_merge.ipro
2. Export the grid with "HEC-RAS text files (*.dat)" filter.

The old iRIC GUI output data like below:

```
NH    16   0.050    0.10   0.050    0.40   0.050    4.47   0.050    5.82   0.080
NH 10.47   0.080   14.49   0.080   18.27   0.080   21.69   0.080   37.07   0.050
NH 39.12   0.050   48.04   0.050   51.96   0.050   64.11   0.050   66.48   0.050
NH 68.43   0.050   68.51      
```

The new iRIC GUI outout data like below:

```
NH     3   0.050    5.82   0.080   37.07   0.050   68.51      
```

[pr-941.zip](https://github.com/i-RIC/prepost-gui/files/6365296/pr-941.zip)
