### PR TITLE
Close #966

### DIFF
--- a/libs/post/post3d/datamodel/post3dwindownodevectorarrowdataitem.cpp
+++ b/libs/post/post3d/datamodel/post3dwindownodevectorarrowdataitem.cpp
@@ -28,6 +28,9 @@ Post3dWindowNodeVectorArrowDataItem::Post3dWindowNodeVectorArrowDataItem(Post3dW
 {
 	setupStandardItem(Checked, NotReorderable, Deletable);
 
+	auto transform = vtkSmartPointer<vtkTransform>::New();
+	m_transformFilter->SetTransform(transform);
+
 	renderer()->AddActor(m_arrowsActor.actor());
 
 	updateActorSettings();
@@ -161,7 +164,8 @@ void Post3dWindowNodeVectorArrowDataItem::updatePolyData()
 	const auto& srSetting = m_samplingRateSetting;
 	m_extractGrid->SetSampleRate(srSetting.iSamplingRate, srSetting.jSamplingRate, srSetting.kSamplingRate);
 
-	m_extractGrid->SetInputData(ps);
+	m_transformFilter->SetInputData(ps);
+	m_extractGrid->SetInputConnection(m_transformFilter->GetOutputPort());
 	m_extractGrid->Update();
 
 	double height = dataModel()->graphicsView()->stdDistance(m_arrowSetting.arrowSize);


### PR DESCRIPTION
Before merging the pull request, when Z-scale is edited to value other than 1, arrows are not scaled properly, like shown below. After merging, arrows are also scaled properly.

![issue-966-screenshot](https://user-images.githubusercontent.com/4031569/135069599-d150be0e-520f-4219-8fd0-fc27e225af8a.png)
![issue-966-screenshot2](https://user-images.githubusercontent.com/4031569/135078224-fa6b420f-f78f-477e-bb84-6e654f932c88.png)
[issue-966.zip](https://github.com/i-RIC/prepost-gui/files/7243069/issue-966.zip)

