### PR TITLE
Implemented SubEnumerations for Calculation Conditions

### DIFF
--- a/libs/guicore/guicore.pro
+++ b/libs/guicore/guicore.pro
@@ -226,6 +226,7 @@ HEADERS += guicore_global.h \
            project/gcptablemodel.h \
            project/gcptablerow.h \
            project/georeferenceview.h \
+           project/inputcond/private/inputconditiondependencysetsubenumerationsaction.h \
            project/offsetsettingdialog.h \
            project/projectcgnsfile.h \
            project/projectdata.h \
@@ -497,6 +498,7 @@ HEADERS += guicore_global.h \
            project/inputcond/private/inputconditioncontainerreal_impl.h \
            project/inputcond/private/inputconditioncontainerstring_impl.h \
            project/inputcond/private/inputconditiondependencychecksubcaptions.h \
+           project/inputcond/private/inputconditiondependencychecksubenumerations.h \
            project/inputcond/private/inputconditiondependencychecksubimages.h \
            project/inputcond/private/inputconditiondependencyconditionalways.h \
            project/inputcond/private/inputconditiondependencyconditionand.h \
@@ -644,6 +646,7 @@ SOURCES += base/iricmainwindowinterface.cpp \
            project/colorsource.cpp \
            project/gcptablemodel.cpp \
            project/georeferenceview.cpp \
+           project/inputcond/private/inputconditiondependencysetsubenumerationsaction.cpp \
            project/offsetsettingdialog.cpp \
            project/projectcgnsfile.cpp \
            project/projectdata.cpp \
@@ -828,6 +831,7 @@ SOURCES += base/iricmainwindowinterface.cpp \
            project/inputcond/private/inputconditioncgnsfile.cpp \
            project/inputcond/private/inputconditioncgnsfileselectdialog.cpp \
            project/inputcond/private/inputconditiondependencychecksubcaptions.cpp \
+           project/inputcond/private/inputconditiondependencychecksubenumerations.cpp \
            project/inputcond/private/inputconditiondependencychecksubimages.cpp \
            project/inputcond/private/inputconditiondependencyconditionalways.cpp \
            project/inputcond/private/inputconditiondependencyconditionand.cpp \

--- a/libs/guicore/project/inputcond/inputconditionwidget.cpp
+++ b/libs/guicore/project/inputcond/inputconditionwidget.cpp
@@ -44,7 +44,10 @@ QList<QDomNode> InputConditionWidget::getEnums(QDomNode defNode)
 		QDomNodeList noms = enumsNode.childNodes();
 		QList<QDomNode> list;
 		for (int i = 0; i < noms.count(); ++i) {
-			list.append(noms.item(i));
+			QDomNode node = noms.item(i);
+			if (node.nodeName() == "Enumeration") {
+				list.append(node);
+			}
 		}
 		return list;
 	}
@@ -68,4 +71,35 @@ bool InputConditionWidget::hasEnums(QDomNode defNode)
 	QDomNode enumNode = iRIC::getChildNode(defNode, "Enumeration");
 	if (! enumNode.isNull()) {return true;}
 	return false;
+}
+
+// given Definition element check for SubEnumerations
+//
+// SubEnumerations are only valid as children of Enumerations
+// Definition can have only one Enumerations child
+// Enumerations can have zero or more SubEnumerations
+//
+// <Item name="name">
+//   <Definition valueType="type">
+//     <Enumerations>
+//       <Enumeration value="1" caption="Caption 1"/>
+//       <Enumeration value="2" caption="Caption 2"/>
+//       <Enumeration value="3" caption="Caption 3"/>
+//       <SubEnumerations>
+//         <Enumeration value="1" caption="Caption 1"/>
+//         <Enumeration value="2" caption="Caption 2"/>
+//         <Condition/>      <!-- Condition to use SubEnumeration list -->
+//       </SubEnumerations>
+//     </Enumerations>
+//     <Condition/>          <!-- Condition to enable/setvalue of list -->
+//   </Definition>
+// </Item>
+//
+bool InputConditionWidget::hasSubEnums(QDomNode defNode)
+{
+	QDomNode enumsNode = iRIC::getChildNode(defNode, "Enumerations");
+	if (enumsNode.isNull()) { return false; }
+	QDomNode subEnumsNode = iRIC::getChildNode(enumsNode, "SubEnumerations");
+	if (subEnumsNode.isNull()) { return false; }
+	return true;
 }

--- a/libs/guicore/project/inputcond/inputconditionwidget.h
+++ b/libs/guicore/project/inputcond/inputconditionwidget.h
@@ -31,6 +31,7 @@ public:
 	static const int margin = 0;
 	static QList<QDomNode> getEnums(QDomNode defNode);
 	static bool hasEnums(QDomNode defNode);
+	static bool hasSubEnums(QDomNode defNode);
 
 private:
 	std::vector<InputConditionDependency*> m_dependencies;

--- a/libs/guicore/project/inputcond/inputconditionwidgetset.h
+++ b/libs/guicore/project/inputcond/inputconditionwidgetset.h
@@ -46,6 +46,7 @@ private:
 	void buildDepsItem(const QDomNode& itemNode, InputConditionContainerSet& cset);
 	void buildDepsLabel(const QDomNode& labelNode, InputConditionContainerSet& cset);
 	void buildDepsImage(const QDomNode& imageNode, InputConditionContainerSet& cset);
+	void buildDepsOption(const QDomNode& imageNode, InputConditionContainerSet& cset);
 	void buildDep(const QDomNode&, InputConditionContainerSet& cset, InputConditionWidget* w);
 	void addTooltip(InputConditionWidget* widget, QDomNode defNode, const SolverDefinitionTranslator& t);
 

--- a/libs/guicore/project/inputcond/private/inputconditiondependencychecksubenumerations.cpp
+++ b/libs/guicore/project/inputcond/private/inputconditiondependencychecksubenumerations.cpp
@@ -1,0 +1,17 @@
+#include "inputconditiondependencychecksubenumerations.h"
+#include "inputconditionwidgetintegeroption.h"
+
+
+InputConditionDependencyCheckSubEnumerations::InputConditionDependencyCheckSubEnumerations(InputConditionWidgetIntegerOption* integerOption) :
+	InputConditionDependency(),
+	m_integerOption(integerOption)
+{}
+
+void InputConditionDependencyCheckSubEnumerations::check()
+{
+	m_integerOption->inactivateSubEnumerations();
+
+	for (auto dep : m_integerOption->dependencies()) {
+		dep->check();
+	}
+}

--- a/libs/guicore/project/inputcond/private/inputconditiondependencychecksubenumerations.h
+++ b/libs/guicore/project/inputcond/private/inputconditiondependencychecksubenumerations.h
@@ -1,0 +1,22 @@
+#ifndef INPUTCONDITIONDEPENDENCYCHECKSUBENUMERATIONS_H
+#define INPUTCONDITIONDEPENDENCYCHECKSUBENUMERATIONS_H
+
+#include "../inputconditiondependency.h"
+
+class InputConditionWidgetIntegerOption;
+
+class InputConditionDependencyCheckSubEnumerations : public InputConditionDependency
+{
+	Q_OBJECT
+
+public:
+	InputConditionDependencyCheckSubEnumerations(InputConditionWidgetIntegerOption* integerOption);
+
+public slots:
+	void check() override;
+
+private:
+	InputConditionWidgetIntegerOption* m_integerOption;
+};
+
+#endif // INPUTCONDITIONDEPENDENCYCHECKSUBENUMERATIONS_H

--- a/libs/guicore/project/inputcond/private/inputconditiondependencysetsubenumerationsaction.cpp
+++ b/libs/guicore/project/inputcond/private/inputconditiondependencysetsubenumerationsaction.cpp
@@ -1,0 +1,22 @@
+#include "inputconditiondependencysetsubenumerationsaction.h"
+
+#include "inputconditiondependencysetsubenumerationsaction.h"
+#include "inputconditionwidgetintegeroption.h"
+
+InputConditionDependencySetSubEnumerationsAction::InputConditionDependencySetSubEnumerationsAction(InputConditionWidgetIntegerOption* w, const QString& name) :
+    InputConditionDependency::Action(w),
+    m_name{ name }
+{}
+
+InputConditionDependencySetSubEnumerationsAction::~InputConditionDependencySetSubEnumerationsAction()
+{}
+
+void InputConditionDependencySetSubEnumerationsAction::positiveAction()
+{
+    InputConditionWidgetIntegerOption* option = dynamic_cast<InputConditionWidgetIntegerOption*> (m_target);
+    Q_ASSERT(option != nullptr);
+    option->activateSubEnumerations(m_name);
+}
+
+void InputConditionDependencySetSubEnumerationsAction::negativeAction()
+{}

--- a/libs/guicore/project/inputcond/private/inputconditiondependencysetsubenumerationsaction.h
+++ b/libs/guicore/project/inputcond/private/inputconditiondependencysetsubenumerationsaction.h
@@ -1,0 +1,22 @@
+#ifndef INPUTCONDITIONDEPENDENCYSETSUBENUMERATIONSACTION_H
+#define INPUTCONDITIONDEPENDENCYSETSUBENUMERATIONSACTION_H
+
+#include "../inputconditiondependency.h"
+
+class InputConditionWidgetIntegerOption;
+
+
+class InputConditionDependencySetSubEnumerationsAction : public InputConditionDependency::Action
+{
+public:
+    InputConditionDependencySetSubEnumerationsAction(InputConditionWidgetIntegerOption* w, const QString& name);
+    ~InputConditionDependencySetSubEnumerationsAction();
+
+    void positiveAction();
+    void negativeAction();
+
+private:
+    QString m_name;
+};
+
+#endif // INPUTCONDITIONDEPENDENCYSETSUBENUMERATIONSACTION_H

--- a/libs/guicore/project/inputcond/private/inputconditionwidgetintegeroption.cpp
+++ b/libs/guicore/project/inputcond/private/inputconditionwidgetintegeroption.cpp
@@ -1,5 +1,6 @@
 #include "../../../solverdef/solverdefinitiontranslator.h"
 #include "../inputconditioncontainerinteger.h"
+#include "inputconditiondependencychecksubenumerations.h"
 #include "inputconditionwidgetintegeroption.h"
 #include "inputconditionwidgettooltip.h"
 
@@ -28,10 +29,37 @@ InputConditionWidgetIntegerOption::InputConditionWidgetIntegerOption(QDomNode de
 		QDomElement nomElem = nomNode.toElement();
 		int nomValue = nomElem.attribute("value").toInt();
 		QString caption = t.translate(nomElem.attribute("caption"));
+		// store default list
+		m_enumerations.push_back(std::pair<QString, QVariant>(caption, QVariant(nomValue)));
 		m_comboBox->addItem(caption, QVariant(nomValue));
 	}
 	m_container = cont;
 	setValue(cont->value());
+
+	if (hasSubEnums(defnode)) {
+		// SubEnumerations must have an Enumerations parent
+		QDomNode enumsNode = iRIC::getChildNode(defnode, "Enumerations");
+		QDomNodeList children = enumsNode.childNodes();
+		for (int i = 0; i < children.count(); ++i) {
+			QDomNode subEnums = children.at(i);
+			if (subEnums.nodeName() != "SubEnumerations") { continue; }
+			// create unique name to lookup list
+			QString name = subEnumerationsName(subEnums, m_subEnumerations.size());
+			QDomNodeList nodes = subEnums.childNodes();
+			for (int n = 0; n < nodes.size(); ++n) {
+				QDomNode enumNode = nodes.at(n);
+				if (enumNode.nodeName() != "Enumeration") { continue; }
+				QDomElement enumElem = enumNode.toElement();
+				int value = enumElem.attribute("value").toInt();
+				QString caption = t.translate(enumElem.attribute("caption"));
+				// append to sub-list
+				m_subEnumerations[name].push_back({ caption, QVariant(value) });
+			}
+		}
+	}
+	// check
+	m_checkSubEnumerations = new InputConditionDependencyCheckSubEnumerations(this);
+
 	// connect
 	connect(m_container, SIGNAL(valueChanged(int)), this, SLOT(setValue(int)));
 	connect(m_comboBox, SIGNAL(currentIndexChanged(int)), this, SLOT(informChange(int)));
@@ -60,4 +88,34 @@ void InputConditionWidgetIntegerOption::informChange(int index)
 {
 	int value = m_comboBox->itemData(index).toInt();
 	m_container->setValue(value);
+}
+
+QString InputConditionWidgetIntegerOption::subEnumerationsName(const QDomNode& subEnumerationsNode, size_t index)
+{
+	Q_UNUSED(subEnumerationsNode);
+	return QString("SubEnums-%1").arg(index);
+}
+
+void InputConditionWidgetIntegerOption::activateSubEnumerations(const QString& name)
+{
+	std::map< QString, std::list< std::pair<QString, QVariant> > >::iterator it = m_subEnumerations.find(name);
+	if (it == m_subEnumerations.end()) { return; }
+
+	m_comboBox->clear();
+	for (auto& p : it->second) {
+		m_comboBox->addItem(p.first, p.second);
+	}
+}
+
+void InputConditionWidgetIntegerOption::inactivateSubEnumerations()
+{
+	m_comboBox->clear();
+	for (auto& p : m_enumerations) {
+		m_comboBox->addItem(p.first, p.second);
+	}
+}
+
+InputConditionDependencyCheckSubEnumerations* InputConditionWidgetIntegerOption::checkSubEnumerations() const
+{
+	return m_checkSubEnumerations;
 }

--- a/libs/guicore/project/inputcond/private/inputconditionwidgetintegeroption.cpp
+++ b/libs/guicore/project/inputcond/private/inputconditionwidgetintegeroption.cpp
@@ -11,6 +11,7 @@
 #include <QDomNode>
 #include <QDomNodeList>
 #include <QHBoxLayout>
+#include <QSignalBlocker>
 #include <QVariant>
 
 InputConditionWidgetIntegerOption::InputConditionWidgetIntegerOption(QDomNode defnode, const SolverDefinitionTranslator& t, InputConditionContainerInteger* cont) : InputConditionWidget(defnode)
@@ -101,18 +102,30 @@ void InputConditionWidgetIntegerOption::activateSubEnumerations(const QString& n
 	std::map< QString, std::list< std::pair<QString, QVariant> > >::iterator it = m_subEnumerations.find(name);
 	if (it == m_subEnumerations.end()) { return; }
 
+	const QSignalBlocker blocker(m_comboBox);
 	m_comboBox->clear();
 	for (auto& p : it->second) {
 		m_comboBox->addItem(p.first, p.second);
 	}
+	if (m_comboBox->findData(m_container->value()) == -1) {
+		m_container->setValue(m_container->defaultValue());
+	}
+	Q_ASSERT(m_comboBox->findData(m_container->value()) != -1);
+	setValue(m_container->value());
 }
 
 void InputConditionWidgetIntegerOption::inactivateSubEnumerations()
 {
+	const QSignalBlocker blocker(m_comboBox);
 	m_comboBox->clear();
 	for (auto& p : m_enumerations) {
 		m_comboBox->addItem(p.first, p.second);
 	}
+	if (m_comboBox->findData(m_container->value()) == -1) {
+		m_container->setValue(m_container->defaultValue());
+	}
+	Q_ASSERT(m_comboBox->findData(m_container->value()) != -1);
+	setValue(m_container->value());
 }
 
 InputConditionDependencyCheckSubEnumerations* InputConditionWidgetIntegerOption::checkSubEnumerations() const

--- a/libs/guicore/project/inputcond/private/inputconditionwidgetintegeroption.h
+++ b/libs/guicore/project/inputcond/private/inputconditionwidgetintegeroption.h
@@ -4,6 +4,7 @@
 #include "../inputconditionwidget.h"
 
 class InputConditionContainerInteger;
+class InputConditionDependencyCheckSubEnumerations;
 class SolverDefinitionTranslator;
 
 class QComboBox;
@@ -19,6 +20,13 @@ public:
 
 	void setDisabled(bool disable);
 
+	static QString subEnumerationsName(const QDomNode& subEnumerationsNode, size_t index);
+
+	void activateSubEnumerations(const QString& name);
+	void inactivateSubEnumerations();
+
+	InputConditionDependencyCheckSubEnumerations* checkSubEnumerations() const;
+
 public slots:
 	void setValue(int);
 
@@ -28,6 +36,9 @@ private slots:
 private:
 	InputConditionContainerInteger* m_container;
 	QComboBox* m_comboBox;
+	std::list< std::pair<QString, QVariant> > m_enumerations;
+	std::map< QString, std::list< std::pair<QString, QVariant> > > m_subEnumerations;
+	InputConditionDependencyCheckSubEnumerations* m_checkSubEnumerations;
 };
 
 #endif // INPUTCONDITIONWIDGETINTEGEROPTION_H


### PR DESCRIPTION
Hi Keisuke,

I implemented SubEnumerations like we talked about a few weeks ago.

Here's a sample:

```
<Item name="name">
  <Definition valueType="type">
    <Enumerations>
      <Enumeration value="1" caption="Caption 1"/>
      <Enumeration value="2" caption="Caption 2"/>
      <Enumeration value="3" caption="Caption 3"/>
      <SubEnumerations>
        <Enumeration value="1" caption="Caption 1"/>
        <Enumeration value="2" caption="Caption 2"/>
        <Condition/>      <!-- Condition to use SubEnumeration list -->
      </SubEnumerations>
    </Enumerations>
    <Condition/>          <!-- Condition to enable/setvalue of list -->
  </Definition>
</Item>
```

And here are some sample solvers to test it with:

[SubEnumerations.zip](https://github.com/i-RIC/prepost-gui/files/8076187/SubEnumerations.zip)

[cap.new.zip](https://github.com/i-RIC/prepost-gui/files/8076188/cap.new.zip)

cap.new Contains the latest cap version with modifications that the CAP guys wanted (see items 2 & 3):

https://github.com/i-RIC/solver.cap/issues/4#issuecomment-1041010686

Thanks,
Scott




