### PR TITLE
Close #1019

### DIFF
--- a/libs/pre/preprocessordatamodel.cpp
+++ b/libs/pre/preprocessordatamodel.cpp
@@ -1396,6 +1396,14 @@ bool PreProcessorDataModel::checkMappingStatus()
 	PreProcessorRootDataItem* r = dynamic_cast<PreProcessorRootDataItem*>(m_rootDataItem);
 	bool mapExexuted = false;
 	for (auto gtItem : r->gridTypeDataItems()) {
+		bool gridsExists = false;
+		for (auto cond : gtItem->conditions()) {
+			if (cond->gridDataItem()->grid() != nullptr) {
+				gridsExists = true;
+			}
+		}
+		if (!gridsExists) {continue;}
+
 		QStringList notMapped;
 		QList<PreProcessorGeoDataGroupDataItemInterface*> groupsToMap;
 		for (auto gItem : gtItem->geoDataTop()->groupDataItems()) {


### PR DESCRIPTION
The behavior is changed like below:

* When grid does not exists, dialog to ask if user wants to map edited geographic data to grid is not shown.
* When grid does not exists, the dialog to warn that grid does not exist is shown.
