### PR TITLE
Close #1027

### DIFF
--- a/libs/gui/continuoussnapshot/continuoussnapshotgoogleearthsettingpage.h
+++ b/libs/gui/continuoussnapshot/continuoussnapshotgoogleearthsettingpage.h
@@ -26,10 +26,10 @@ public:
 	QSize targetSnapshotSize();
 
 private:
-	void snapshotToWorld(QPointF& p);
-	void worldToLatLong(QPointF& p);
+	QPointF snapshotToWorld(const QPointF& p);
+	QPointF worldToLatLong(const QPointF& p);
 
-	void snapshotToLatLong(QPointF& p);
+	QPointF snapshotToLatLong(const QPointF& p);
 
 	iRICMainWindow* m_mainWindow;
 	ContinuousSnapshotWizard* m_wizard;


### PR DESCRIPTION
iRIC export invalid KML file when the view is rotated, and the image exported by iRIC is mapped to ground in wrong position.

You can test it with the file attached to #1027.
