### PR TITLE
Close #1029

### DIFF
--- a/libs/pre/datamodel/preprocessorgeodatagroupdataitem.cpp
+++ b/libs/pre/datamodel/preprocessorgeodatagroupdataitem.cpp
@@ -580,7 +580,6 @@ void PreProcessorGeoDataGroupDataItem::importGeoData(GeoDataImporter* importer, 
 	QWidget* w = preProcessorWindow();
 	bool ret = importer->importInit(filename, selectedFilter, &dataCount, m_condition, this, w);
 	if (! ret) {
-		QMessageBox::warning(preProcessorWindow(), tr("Import failed"), tr("Importing data from %1 failed.").arg(QDir::toNativeSeparators(filename)));
 		return;
 	}
 	if (dataCount == 0){


### PR DESCRIPTION
iRIC shows needless warning dialog, when user cancels importing geographic data.

1. Start a new project for Nays2DH
2. Select Imoprt -> Geographic Data -> Elevation (m)
3. Select I27-35.riv, and click on "Open" button.
4. On "Problems Found in Data" dialog, click on "Cancel" button.

After merging the commit, the dialog with message "Importing data from (filename) failed". is not shown.

[I27-35.zip](https://github.com/i-RIC/prepost-gui/files/8601609/I27-35.zip)